### PR TITLE
feat(kvm, sol): adds error message on failure

### DIFF
--- a/src/app/devices/kvm/kvm.component.spec.ts
+++ b/src/app/devices/kvm/kvm.component.spec.ts
@@ -13,6 +13,7 @@ import { ActivatedRoute } from '@angular/router'
 import { Component, EventEmitter, Input } from '@angular/core'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { AuthService } from 'src/app/auth.service'
+import SnackbarDefaults from 'src/app/shared/config/snackBarDefault'
 
 describe('KvmComponent', () => {
   let component: KvmComponent
@@ -74,5 +75,19 @@ describe('KvmComponent', () => {
     expect(powerStateSpy).toHaveBeenCalled()
     expect(getAMTFeaturesSpy).toHaveBeenCalled()
     expect(reqUserConsentCodeSpy).toHaveBeenCalled()
+  })
+  it('should show error and hide loading when disconnected', () => {
+    const snackBarSpy = spyOn(component.snackBar, 'open')
+    component.deviceStatus(0)
+    expect(snackBarSpy).toHaveBeenCalledOnceWith('Connecting to KVM failed. Only one session per device is allowed. Also ensure that your token is valid and you have access.', undefined, SnackbarDefaults.defaultError)
+    expect(component.isLoading).toBeFalse()
+    expect(component.deviceState).toBe(0)
+  })
+  it('should  hide loading when connected', () => {
+    const snackBarSpy = spyOn(component.snackBar, 'open')
+    component.deviceStatus(2)
+    expect(snackBarSpy).not.toHaveBeenCalled()
+    expect(component.isLoading).toBeFalse()
+    expect(component.deviceState).toBe(2)
   })
 })

--- a/src/app/devices/kvm/kvm.component.ts
+++ b/src/app/devices/kvm/kvm.component.ts
@@ -231,11 +231,13 @@ export class KvmComponent implements OnInit, OnDestroy {
   }
 
   deviceStatus = (event: any): void => {
+    this.deviceState = event
+
     if (event === 2) {
-      this.deviceState = event
       this.isLoading = false
-    } else {
-      this.deviceState = event
+    } else if (event === 0) {
+      this.isLoading = false
+      this.snackBar.open('Connecting to KVM failed. Only one session per device is allowed. Also ensure that your token is valid and you have access.', undefined, SnackbarDefaults.defaultError)
     }
   }
 

--- a/src/app/devices/sol/sol.component.spec.ts
+++ b/src/app/devices/sol/sol.component.spec.ts
@@ -9,6 +9,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { SharedModule } from 'src/app/shared/shared.module'
 import { RouterTestingModule } from '@angular/router/testing'
 import { AuthService } from 'src/app/auth.service'
+import SnackbarDefaults from 'src/app/shared/config/snackBarDefault'
 
 describe('SolComponent', () => {
   let component: SolComponent
@@ -69,5 +70,19 @@ describe('SolComponent', () => {
     expect(setAmtFeaturesSpy).toHaveBeenCalled()
     expect(getAMTFeaturesSpy).toHaveBeenCalled()
     expect(reqUserConsentCodeSpy).toHaveBeenCalled()
+  })
+  it('should show error and hide loading when disconnected', () => {
+    const snackBarSpy = spyOn(component.snackBar, 'open')
+    component.deviceStatus(0)
+    expect(snackBarSpy).toHaveBeenCalledOnceWith('Connecting to KVM failed. Only one session per device is allowed. Also ensure that your token is valid and you have access.', undefined, SnackbarDefaults.defaultError)
+    expect(component.isLoading).toBeFalse()
+    expect(component.deviceState).toBe(0)
+  })
+  it('should  hide loading when connected', () => {
+    const snackBarSpy = spyOn(component.snackBar, 'open')
+    component.deviceStatus(3)
+    expect(snackBarSpy).not.toHaveBeenCalled()
+    expect(component.isLoading).toBeFalse()
+    expect(component.deviceState).toBe(3)
   })
 })

--- a/src/app/devices/sol/sol.component.ts
+++ b/src/app/devices/sol/sol.component.ts
@@ -206,11 +206,12 @@ export class SolComponent implements OnInit {
   }
 
   deviceStatus (event: any): void {
+    this.deviceState = event
     if (event === 3) {
-      this.deviceState = event
       this.isLoading = false
-    } else {
-      this.deviceState = event
+    } else if (event === 0) {
+      this.isLoading = false
+      this.snackBar.open('Connecting to KVM failed. Only one session per device is allowed. Also ensure that your token is valid and you have access.', undefined, SnackbarDefaults.defaultError)
     }
   }
 


### PR DESCRIPTION
When a secondary connection for KVM or SOL occurs, or token validation fails an error message is displayed to the user. This also address the spinning loading bar to be removed when failure to connect.

closes: [AB#6477](https://dev.azure.com/rbheBoards/c7d9d701-a85f-45ff-91f6-26c56ff2c4de/_workitems/edit/6477) [AB#4148](https://dev.azure.com/rbheBoards/c7d9d701-a85f-45ff-91f6-26c56ff2c4de/_workitems/edit/4148)

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->


## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )
