### PR TITLE
feat: support Alarm Service APIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
-RUN npm run build --
+RUN npm run build -- --configuration=production
 
 ### STAGE 2: Run ###
 FROM nginx:latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@open-amt-cloud-toolkit/sample-web-ui",
       "version": "2.4.0",
       "dependencies": {
+        "@angular-material-components/datetime-picker": "^8.0.0",
         "@angular/animations": "~14.1.0",
         "@angular/cdk": "~14.1.0",
         "@angular/common": "~14.1.0",
@@ -823,6 +824,22 @@
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0",
         "typescript": "*"
+      }
+    },
+    "node_modules/@angular-material-components/datetime-picker": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-material-components/datetime-picker/-/datetime-picker-8.0.0.tgz",
+      "integrity": "sha512-mpndWbRimp77omkfa9LlpY21FN8xOFH8NV4hSLOxWg7RpUa1gZXLtW6mTRuDQ9cpWO6m9qH/8ioHKtvY+Epckg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^14.0.1",
+        "@angular/common": "^14.0.1",
+        "@angular/core": "^14.0.1",
+        "@angular/forms": "^14.0.1",
+        "@angular/material": "^14.0.1",
+        "@angular/platform-browser": "^14.0.1"
       }
     },
     "node_modules/@angular/animations": {
@@ -18586,6 +18603,14 @@
       "requires": {
         "@angular-eslint/bundled-angular-compiler": "14.0.2",
         "@typescript-eslint/utils": "5.29.0"
+      }
+    },
+    "@angular-material-components/datetime-picker": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-material-components/datetime-picker/-/datetime-picker-8.0.0.tgz",
+      "integrity": "sha512-mpndWbRimp77omkfa9LlpY21FN8xOFH8NV4hSLOxWg7RpUa1gZXLtW6mTRuDQ9cpWO6m9qH/8ioHKtvY+Epckg==",
+      "requires": {
+        "tslib": "^2.3.0"
       }
     },
     "@angular/animations": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "private": true,
   "dependencies": {
+    "@angular-material-components/datetime-picker": "^8.0.0",
     "@angular/animations": "~14.1.0",
     "@angular/cdk": "~14.1.0",
     "@angular/common": "~14.1.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { DeviceUserConsentComponent } from './devices/device-user-consent/device
 import { IMqttServiceOptions, MqttModule } from 'ngx-mqtt'
 import { EventLogComponent } from './devices/event-log/event-log.component'
 import { EventChannelComponent } from './event-channel/event-channel.component'
+import { NgxMatDatetimePickerModule, NgxMatNativeDateModule, NgxMatTimepickerModule } from '@angular-material-components/datetime-picker'
 
 const MQTT_SERVICE_OPTIONS: IMqttServiceOptions = { protocol: 'wss' }
 
@@ -85,7 +86,10 @@ const MQTT_SERVICE_OPTIONS: IMqttServiceOptions = { protocol: 'wss' }
         component: LoginComponent
       }
     ]),
-    KvmModule
+    KvmModule,
+    NgxMatDatetimePickerModule,
+    NgxMatNativeDateModule,
+    NgxMatTimepickerModule
   ],
   providers: [
     {

--- a/src/app/devices/device-detail/device-detail.component.html
+++ b/src/app/devices/device-detail/device-detail.component.html
@@ -222,6 +222,88 @@
                     </div>
                 </mat-card-content>
             </mat-card>
+            <mat-card fxFlex="calc(50% - 24px)" fxFlex.lt-lg="100" id="alarmService">
+                <mat-card-header>
+                    <mat-card-title>
+                        Alarm Service
+                    </mat-card-title>
+                    <mat-card-subtitle>Alarms ({{alarmOccurrences.length}} entries)</mat-card-subtitle>
+                </mat-card-header>
+                <mat-card-content>
+                    <div *ngFor="let entry of alarmOccurrences" fxLayout="row wrap">
+                        <div style="margin: 12px 0;" fxFlex=100>
+                            <mat-divider></mat-divider>
+                        </div>
+                        <div fxFlex="50">
+                            <span data-cy="alarmElementName">{{entry.ElementName}}</span>
+                        </div>
+                        <div fxFlex="50" fxLayoutAlign="end">
+                            <button fxHide.xs mat-icon-button matTooltip="Delete alarm occurrence" (click)="deleteAlarm(entry.InstanceID)">
+                                <mat-icon>delete</mat-icon>
+                            </button>
+                        </div>
+                        <div fxFlex="50">
+                            <p>InstanceID: </p>
+                        </div>
+                        <div fxFlex="50" fxLayoutAlign="end">
+                            <span class="mat-h3" data-cy="alarmInstanceID"> {{entry.InstanceID}}</span>
+                        </div>
+                        <div fxFlex="50">
+                            <p>Start Time: </p>
+                        </div>
+                                <div fxFlex="50" fxLayoutAlign="end">
+                            <span class="mat-h3" data-cy="alarmStartTime"> {{entry.StartTime.Datetime}}</span>
+                        </div>
+                        <div fxFlex="50">
+                            <p>DeleteOnCompletion: </p>
+                        </div>
+                        <div fxFlex="50" fxLayoutAlign="end">
+                            <span class="mat-h3" data-cy="alarmDeleteOnCompletion"> {{entry.DeleteOnCompletion}}</span>
+                        </div>
+                        <div *ngIf="entry.Interval != null" fxFlex="50">
+                            <p>Interval: </p>
+                        </div>
+                        <div fxFlex="50" *ngIf="entry.Interval != null" fxLayoutAlign="end">
+                            <span class="mat-h3" data-cy="alarmInterval"> {{entry.Interval.Interval}}</span>
+                        </div>
+                    </div>
+                    <div fxLayout="row wrap">
+                        <div style="margin: 12px 0;" fxFlex=100>
+                            <mat-divider></mat-divider>
+                        </div>
+                        <form [formGroup]="newAlarmForm" (ngSubmit)="addAlarm()" fxLayout="row wrap" >
+                            <div fxFlex="100" fxLayoutAlign="end">
+                                <button id="btnAddMale" fxHide.xs mat-button>
+                                    <mat-icon>add</mat-icon> Add New
+                                </button>
+                            </div>
+                            <mat-form-field fxFlex="100">
+                                <input formControlName="alarmName" matInput name="alarmName" placeholder="Alarm Name" required>
+                                <mat-error i18n>This field is required and must be alphanumeric with no symbols.</mat-error>
+                                <mat-hint>Provide a name for this alarm.</mat-hint>
+                            </mat-form-field>
+
+                            <mat-form-field fxFlex="100">
+                                <mat-label>Interval</mat-label>
+                                <input formControlName="interval" matInput name="interval" placeholder="0">
+                                <mat-hint>Interval in minutes for a periodic alarm, 0 for single alarm</mat-hint>
+                            </mat-form-field>
+                            <mat-form-field  fxFlex="100">
+                                <input formControlName="startTime" matInput [ngxMatDatetimePicker]="startTime" placeholder="Choose a date and time" required>
+                                <mat-datepicker-toggle matSuffix [for]="$any(startTime)"></mat-datepicker-toggle>
+                                <ngx-mat-datetime-picker #startTime
+                                    [showSpinners]="true" [showSeconds]="false"
+                                    [stepHour]="1" [stepMinute]="1"
+                                    [touchUi]="false" [enableMeridian]="false"
+                                    [disableMinute]="false" [hideTime]="false">
+                                </ngx-mat-datetime-picker>
+                            </mat-form-field>
+                            <br><br>
+                            <mat-slide-toggle  [formControl]="deleteOnCompletion" [checked]="deleteOnCompletion.value">Delete on completion</mat-slide-toggle>
+                        </form>
+                    </div>
+                </mat-card-content>
+            </mat-card>
             <mat-card fxFlex="calc(50% - 24px)" fxFlex.lt-lg="100" id="memorySummary">
                 <mat-card-header>
                     <mat-card-title>

--- a/src/app/devices/devices.service.spec.ts
+++ b/src/app/devices/devices.service.spec.ts
@@ -6,13 +6,14 @@
 import { TestBed } from '@angular/core/testing'
 import { of, throwError } from 'rxjs'
 import { environment } from 'src/environments/environment'
+import { IPSAlarmClockOccurrence } from 'src/models/models'
 import { AuthService } from '../auth.service'
 
 import { DevicesService } from './devices.service'
 
 describe('DevicesService', () => {
   let service: DevicesService
-  let httpClientSpy: { get: jasmine.Spy, post: jasmine.Spy, patch: jasmine.Spy, delete: jasmine.Spy }
+  let httpClientSpy: { get: jasmine.Spy, post: jasmine.Spy, patch: jasmine.Spy, request: jasmine.Spy }
   const deviceRes = {
     hostname: 'localhost',
     icon: 1,
@@ -34,7 +35,7 @@ describe('DevicesService', () => {
   }
 
   beforeEach(() => {
-    httpClientSpy = jasmine.createSpyObj('HttpClient', ['get', 'post', 'delete', 'patch'])
+    httpClientSpy = jasmine.createSpyObj('HttpClient', ['get', 'post', 'request', 'patch'])
     TestBed.configureTestingModule({
       imports: [AuthService]
     })
@@ -616,6 +617,93 @@ describe('DevicesService', () => {
   it('should return error while getting redirection token', () => {
     httpClientSpy.get.and.returnValue(throwError(error))
     service.getRedirectionExpirationToken('defgh-34567-poiuy').subscribe(null, err => {
+      expect(error).toEqual(err)
+    })
+  })
+
+  it('should return alarm instances', () => {
+    const alarms: IPSAlarmClockOccurrence[] = [{
+      ElementName: 'Alarm name',
+      StartTime: { Datetime: new Date() },
+      InstanceID: 'Alarm instance',
+      DeleteOnCompletion: true
+    }]
+    httpClientSpy.get.and.returnValue(of(alarms))
+    service.getAlarmOccurrences('defgh-34567-poiuy').subscribe(response => {
+      expect(response).toBe(alarms)
+      expect(httpClientSpy.get).toHaveBeenCalledWith(`${environment.mpsServer}/api/v1/amt/alarmOccurrences/defgh-34567-poiuy`)
+    })
+  })
+
+  it('should return error when requesting power state', () => {
+    httpClientSpy.get.and.returnValue(throwError(error))
+    service.getPowerState('defgh-34567-poiuy').subscribe(() => {}, err => {
+      expect(error).toEqual(err)
+    })
+  })
+
+  it('should return alarm instances', () => {
+    const alarms: IPSAlarmClockOccurrence[] = [{
+      ElementName: 'Alarm name',
+      StartTime: { Datetime: new Date() },
+      InstanceID: 'Alarm instance',
+      DeleteOnCompletion: true
+    }]
+    httpClientSpy.get.and.returnValue(of(alarms))
+    service.getAlarmOccurrences('defgh-34567-poiuy').subscribe(response => {
+      expect(response).toBe(alarms)
+      expect(httpClientSpy.get).toHaveBeenCalledWith(`${environment.mpsServer}/api/v1/amt/alarmOccurrences/defgh-34567-poiuy`)
+    })
+  })
+
+  it('should return error when getting alarm instances', () => {
+    httpClientSpy.get.and.returnValue(throwError(error))
+    service.getAlarmOccurrences('defgh-34567-poiuy').subscribe(() => {}, err => {
+      expect(error).toEqual(err)
+    })
+  })
+
+  it('should delete an alarm instance', () => {
+    httpClientSpy.request.and.returnValue(of({ Status: 'SUCCESS' }))
+    service.deleteAlarmOccurrence('defgh-34567-poiuy', 'Alarm to delete').subscribe(response => {
+      expect(response).toEqual({ Status: 'SUCCESS' })
+      expect(httpClientSpy.request).toHaveBeenCalledWith(
+        'DELETE',
+        `${environment.mpsServer}/api/v1/amt/alarmOccurrences/defgh-34567-poiuy`,
+        { body: { Name: 'Alarm to delete' } })
+    })
+  })
+
+  it('should return error when deleting an alarm', () => {
+    httpClientSpy.request.and.returnValue(throwError(error))
+    service.deleteAlarmOccurrence('defgh-34567-poiuy', 'Alarm to delete').subscribe(() => {}, err => {
+      expect(error).toEqual(err)
+    })
+  })
+
+  it('should add an alarm instance', () => {
+    const alarmToAdd = {
+      ElementName: 'Alarm name',
+      StartTime: { Datetime: new Date() },
+      InstanceID: 'Alarm instance',
+      DeleteOnCompletion: true
+    }
+    httpClientSpy.post.and.returnValue(of({ Status: 'SUCCESS' }))
+    service.addAlarmOccurrence('defgh-34567-poiuy', alarmToAdd).subscribe(response => {
+      expect(response).toEqual({ Status: 'SUCCESS' })
+      expect(httpClientSpy.post).toHaveBeenCalledWith(`${environment.mpsServer}/api/v1/amt/alarmOccurrences/defgh-34567-poiuy`, alarmToAdd)
+    })
+  })
+
+  it('should return error when adding an alarm', () => {
+    const alarmToAdd: IPSAlarmClockOccurrence = {
+      ElementName: 'Alarm name',
+      StartTime: { Datetime: new Date() },
+      InstanceID: 'Alarm instance',
+      DeleteOnCompletion: true
+    }
+    httpClientSpy.post.and.returnValue(throwError(error))
+    service.addAlarmOccurrence('defgh-34567-poiuy', alarmToAdd).subscribe(() => {}, err => {
       expect(error).toEqual(err)
     })
   })

--- a/src/app/devices/devices.service.ts
+++ b/src/app/devices/devices.service.ts
@@ -8,7 +8,7 @@ import { EventEmitter, Injectable } from '@angular/core'
 import { Observable } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 import { environment } from 'src/environments/environment'
-import { AmtFeaturesResponse, AuditLogResponse, Device, DeviceResponse, DeviceStats, EventLog, HardwareInformation, PageEventOptions, PowerState, RedirectionToken, userConsentResponse } from 'src/models/models'
+import { AmtFeaturesResponse, AuditLogResponse, Device, DeviceResponse, DeviceStats, EventLog, HardwareInformation, IPSAlarmClockOccurrence, PageEventOptions, PowerState, RedirectionToken, userConsentResponse } from 'src/models/models'
 
 @Injectable({
   providedIn: 'root'
@@ -188,6 +188,36 @@ export class DevicesService {
 
   getAMTFeatures (guid: string): Observable<AmtFeaturesResponse> {
     return this.http.get<AmtFeaturesResponse>(`${environment.mpsServer}/api/v1/amt/features/${guid}`)
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  getAlarmOccurrences (guid: string): Observable<IPSAlarmClockOccurrence[]> {
+    return this.http.get<IPSAlarmClockOccurrence[]>(`${environment.mpsServer}/api/v1/amt/alarmOccurrences/${guid}`)
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  deleteAlarmOccurrence (guid: string, instanceID: string): Observable<any> {
+    const payload = {
+      Name: instanceID
+    }
+    return this.http.request<any>('DELETE', `${environment.mpsServer}/api/v1/amt/alarmOccurrences/${guid}`, { body: payload })
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  addAlarmOccurrence (guid: string, alarm: any): Observable<any> {
+    return this.http.post<any>(`${environment.mpsServer}/api/v1/amt/alarmOccurrences/${guid}`, alarm)
       .pipe(
         catchError((err) => {
           throw err

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -269,6 +269,14 @@ export interface CIMPhysicalPackage {
   ChassisPackageType?: number
 }
 
+export interface IPSAlarmClockOccurrence {
+  ElementName: string
+  InstanceID: string
+  StartTime: { Datetime: Date }
+  Interval?: { Interval: any }
+  DeleteOnCompletion: boolean
+}
+
 export interface HardwareResponse<T> {
   response: T
   responses: any


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [X] All commented code has been removed
- [X] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?

Adding simple UI to display, delete and add alarm occurrences.


## Anything the reviewer should know when reviewing this PR?

It's about as simple as it gets.  It displays existing alarms in the device details page.  The trash cans delete alarms.  Fill in fields below the list of existing alarms and click "+Add New" to add an alarm.  It would have been better to overlay a separate page to add an alarm and someone more skilled with angular than me is welcome to do it.

Alarms times are rounded down to the nearest minute (AMT doesn't allow finer resolution).  Similarly, intervals for periodic alarms are set in minutes.

Alarm names should be at most 32 characters and should be unique as the InstanceID will be set to the same as the alarm name.

Local time will be converted to, and passed to AMT as UTC.

Screenshot for the record:

![image](https://user-images.githubusercontent.com/11839044/182738340-b884d87a-457c-4992-8318-b3a456a460dd.png)

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )

mps: https://github.com/open-amt-cloud-toolkit/mps/pull/658
wsman-messages: https://github.com/open-amt-cloud-toolkit/wsman-messages/pull/180

The start time field for adding an alarm uses the following package which has an MIT license:

```@angular-material-components/datetime-picker```
