### PR TITLE
fix: addresses issue with blank guid when saving non-cira device

### DIFF
--- a/src/app/shared/add-device-enterprise/add-device-enterprise.component.spec.ts
+++ b/src/app/shared/add-device-enterprise/add-device-enterprise.component.spec.ts
@@ -112,7 +112,7 @@ describe('AddDeviceEnterpriseComponent', () => {
     expect(component.useCIRA).toBe(false)
   })
 
-  it('should reset CIRA fields when CIRA is disabled', () => {
+  it('should reset MPS fields but preserve guid when CIRA is disabled', () => {
     component.form.patchValue({
       guid: 'test-guid-123',
       mpsusername: 'customUser'
@@ -120,7 +120,7 @@ describe('AddDeviceEnterpriseComponent', () => {
 
     component.onCIRAChange(false)
 
-    expect(component.form.get('guid')?.value).toBe('')
+    expect(component.form.get('guid')?.value).toBe('test-guid-123')
     expect(component.form.get('mpsusername')?.value).toBe('admin')
   })
 

--- a/src/app/shared/add-device-enterprise/add-device-enterprise.component.ts
+++ b/src/app/shared/add-device-enterprise/add-device-enterprise.component.ts
@@ -128,7 +128,6 @@ export class AddDeviceEnterpriseComponent {
       this.form.controls['username'].enable()
       this.form.controls['mpsusername'].enable()
       this.form.patchValue({
-        guid: '',
         mpsusername: 'admin',
         mpspassword: ''
       })


### PR DESCRIPTION
fix: addresses issue with blank guid when saving non-cira device in enterprise mode

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
