### PR TITLE
fix: hide edit device button in cloud deployment mode

### DIFF
--- a/src/app/devices/device-toolbar/device-toolbar.component.html
+++ b/src/app/devices/device-toolbar/device-toolbar.component.html
@@ -35,9 +35,12 @@
       <mat-chip>{{ tag }}</mat-chip>
     }
   </mat-chip-set>
-  <button mat-icon-button [matTooltip]="'devices.editDevice.value' | translate" (click)="editDevice()">
-    <mat-icon>edit</mat-icon>
-  </button>
+  @if (!isCloudMode) {
+    <button mat-icon-button [matTooltip]="'devices.editDevice.value' | translate" (click)="editDevice()">
+      <mat-icon>edit</mat-icon>
+    </button>
+  }
+
   <button
     mat-icon-button
     [matTooltip]="

--- a/src/app/devices/devices.component.html
+++ b/src/app/devices/devices.component.html
@@ -178,12 +178,14 @@
                   (click)="$event.stopPropagation(); sendDeactivate(element.guid)">
                   <mat-icon>delete</mat-icon>
                 </button>
-                <button
-                  mat-icon-button
-                  [matTooltip]="'devices.actions.edit.value' | translate"
-                  (click)="$event.stopPropagation(); editDevice(element)">
-                  <mat-icon>edit</mat-icon>
-                </button>
+                @if (!isCloudMode) {
+                  <button
+                    mat-icon-button
+                    [matTooltip]="'devices.actions.edit.value' | translate"
+                    (click)="$event.stopPropagation(); editDevice(element)">
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                }
               </div>
             }
           </mat-cell>


### PR DESCRIPTION
The edit device functionality is not supported in cloud deployments.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
