### PR TITLE
perf: improve KVM connection time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@xterm/xterm": "^6.0.0",
         "angular-oauth2-oidc": "^20.0.2",
         "angular-oauth2-oidc-jwks": "^20.0.0",
-        "cypress": "15.14.1",
         "date-fns": "^4.1.0",
         "esbuild": "^0.28.0",
         "monaco-editor": "^0.55.1",

--- a/src/app/devices/device-toolbar/device-toolbar.component.spec.ts
+++ b/src/app/devices/device-toolbar/device-toolbar.component.spec.ts
@@ -37,6 +37,7 @@ describe('DeviceToolbarComponent', () => {
       'getDevice',
       'sendDeactivate',
       'getPowerState',
+      'getPowerStateCached',
       'getAMTFeatures',
       'getAMTFeaturesCached',
       'getAMTVersion',
@@ -55,6 +56,7 @@ describe('DeviceToolbarComponent', () => {
     )
 
     devicesService.getPowerState.and.returnValue(of({ powerstate: 2 }))
+    devicesService.getPowerStateCached.and.returnValue(of({ powerstate: 2 }))
     const mockAMTFeatures = {
       userConsent: 'None',
       ocr: true,

--- a/src/app/devices/device-toolbar/device-toolbar.component.ts
+++ b/src/app/devices/device-toolbar/device-toolbar.component.ts
@@ -219,8 +219,10 @@ export class DeviceToolbarComponent implements OnInit {
 
   getPowerState(): void {
     this.isLoading().set(true)
+    // Goes through the cached variant so a simultaneous KVM deep-link fetch and
+    // this toolbar fetch are deduped into one /power/state round-trip.
     this.devicesService
-      .getPowerState(this.deviceId())
+      .getPowerStateCached(this.deviceId())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((powerState) => {
         this.powerState.set(

--- a/src/app/devices/devices.service.spec.ts
+++ b/src/app/devices/devices.service.spec.ts
@@ -80,28 +80,28 @@ describe('DevicesService', () => {
   })
 
   describe('getAMTFeatures', () => {
-    it('should fetch AMT features for a device', () => {
-      const mockResponse: AMTFeaturesResponse = {
-        userConsent: 'none',
-        optInState: 0,
-        redirection: true,
-        kvmAvailable: true,
-        KVM: true,
-        SOL: true,
-        IDER: true,
-        ocr: false,
-        httpsBootSupported: false,
-        winREBootSupported: false,
-        localPBABootSupported: false,
-        remoteErase: false,
-        pbaBootFilesPath: [],
-        winREBootFilesPath: {
-          instanceID: '',
-          biosBootString: '',
-          bootString: ''
-        }
+    const mockResponse: AMTFeaturesResponse = {
+      userConsent: 'none',
+      optInState: 0,
+      redirection: true,
+      kvmAvailable: true,
+      KVM: true,
+      SOL: true,
+      IDER: true,
+      ocr: false,
+      httpsBootSupported: false,
+      winREBootSupported: false,
+      localPBABootSupported: false,
+      remoteErase: false,
+      pbaBootFilesPath: [],
+      winREBootFilesPath: {
+        instanceID: '',
+        biosBootString: '',
+        bootString: ''
       }
+    }
 
+    it('should fetch AMT features for a device', () => {
       service.getAMTFeatures('device1').subscribe((response) => {
         expect(response).toEqual(mockResponse)
       })
@@ -122,6 +122,49 @@ describe('DevicesService', () => {
 
       const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/features/device1`)
       req.flush(null, mockError)
+    })
+
+    it('populates the featuresChanges stream on success', () => {
+      const emitted: any[] = []
+      service.featuresChanges('device1').subscribe((v) => emitted.push(v))
+      service.getAMTFeatures('device1').subscribe()
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/features/device1`)
+      req.flush(mockResponse)
+      expect(emitted).toEqual([
+        null,
+        mockResponse
+      ])
+    })
+
+    describe('getAMTFeaturesCached', () => {
+      it('returns the cached value without an HTTP call when present', () => {
+        service.getAMTFeatures('device1').subscribe()
+        httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/features/device1`).flush(mockResponse)
+
+        let cached: AMTFeaturesResponse | undefined
+        service.getAMTFeaturesCached('device1').subscribe((r) => (cached = r))
+        httpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/amt/features/device1`)
+        expect(cached).toEqual(mockResponse)
+      })
+
+      it('falls through to HTTP when no cache is present', () => {
+        service.getAMTFeaturesCached('device1').subscribe()
+        const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/features/device1`)
+        req.flush(mockResponse)
+      })
+
+      it('dedupes simultaneous callers into a single HTTP request', () => {
+        let first: AMTFeaturesResponse | undefined
+        let second: AMTFeaturesResponse | undefined
+        service.getAMTFeaturesCached('device1').subscribe((r) => (first = r))
+        service.getAMTFeaturesCached('device1').subscribe((r) => (second = r))
+
+        const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/features/device1`)
+        req.flush(mockResponse)
+
+        expect(first).toEqual(mockResponse)
+        expect(second).toEqual(mockResponse)
+      })
     })
   })
 
@@ -561,9 +604,9 @@ describe('DevicesService', () => {
   })
 
   describe('getPowerState', () => {
-    it('should fetch power state for a device', () => {
-      const mockResponse: PowerState = { powerstate: 2 }
+    const mockResponse: PowerState = { powerstate: 2 }
 
+    it('should fetch power state for a device', () => {
       service.getPowerState('device1').subscribe((response) => {
         expect(response).toEqual(mockResponse)
       })
@@ -584,6 +627,46 @@ describe('DevicesService', () => {
 
       const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/power/state/device1`)
       req.flush(null, mockError)
+    })
+
+    it('populates the powerStateChanges stream on success', () => {
+      const emitted: any[] = []
+      service.powerStateChanges('device1').subscribe((v) => emitted.push(v))
+      service.getPowerState('device1').subscribe()
+      httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/power/state/device1`).flush(mockResponse)
+      expect(emitted).toEqual([
+        null,
+        mockResponse
+      ])
+    })
+
+    describe('getPowerStateCached', () => {
+      it('returns the cached value without an HTTP call when present', () => {
+        service.getPowerState('device1').subscribe()
+        httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/power/state/device1`).flush(mockResponse)
+
+        let cached: PowerState | undefined
+        service.getPowerStateCached('device1').subscribe((r) => (cached = r))
+        httpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/amt/power/state/device1`)
+        expect(cached).toEqual(mockResponse)
+      })
+
+      it('falls through to HTTP when no cache is present', () => {
+        service.getPowerStateCached('device1').subscribe()
+        httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/power/state/device1`).flush(mockResponse)
+      })
+
+      it('dedupes simultaneous callers into a single HTTP request', () => {
+        let first: PowerState | undefined
+        let second: PowerState | undefined
+        service.getPowerStateCached('device1').subscribe((r) => (first = r))
+        service.getPowerStateCached('device1').subscribe((r) => (second = r))
+
+        httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/power/state/device1`).flush(mockResponse)
+
+        expect(first).toEqual(mockResponse)
+        expect(second).toEqual(mockResponse)
+      })
     })
   })
 

--- a/src/app/devices/devices.service.ts
+++ b/src/app/devices/devices.service.ts
@@ -6,7 +6,7 @@
 import { HttpClient } from '@angular/common/http'
 import { EventEmitter, Injectable, inject } from '@angular/core'
 import { Observable, Subject, BehaviorSubject, of } from 'rxjs'
-import { catchError, map, tap } from 'rxjs/operators'
+import { catchError, finalize, map, shareReplay, tap } from 'rxjs/operators'
 import { environment } from 'src/environments/environment'
 import {
   AMTFeaturesResponse,
@@ -41,23 +41,33 @@ import { TranslateService } from '@ngx-translate/core'
 })
 export class DevicesService {
   private readonly http = inject(HttpClient)
-  // Reactive AMT features stream, keyed by deviceId
   private readonly amtFeaturesStreams = new Map<string, BehaviorSubject<AMTFeaturesResponse | null>>()
-  // Timestamps for TTL-based features cache — configured via environment.amtFeaturesCacheTtlMs, capped at 3 min
-  private readonly featuresTimestamps = new Map<string, number>()
-  private readonly FEATURES_TTL_MS = Math.min(environment.amtFeaturesCacheTtlMs ?? 30_000, 180_000)
+  private readonly powerStateStreams = new Map<string, BehaviorSubject<PowerState | null>>()
+  // In-flight HTTP requests, shared so simultaneous callers (e.g. toolbar and
+  // general components whose ngOnInit fires together) hit the same response.
+  private readonly featuresInflight = new Map<string, Observable<AMTFeaturesResponse>>()
+  private readonly powerStateInflight = new Map<string, Observable<PowerState>>()
 
   private getOrCreateFeaturesStream(deviceId: string): BehaviorSubject<AMTFeaturesResponse | null> {
     if (!this.amtFeaturesStreams.has(deviceId)) {
       this.amtFeaturesStreams.set(deviceId, new BehaviorSubject<AMTFeaturesResponse | null>(null))
     }
-    // Non-null assertion safe because we just set it above when missing
     return this.amtFeaturesStreams.get(deviceId)!
   }
 
-  // Public observable for other components to react to AMT features changes
+  private getOrCreatePowerStateStream(deviceId: string): BehaviorSubject<PowerState | null> {
+    if (!this.powerStateStreams.has(deviceId)) {
+      this.powerStateStreams.set(deviceId, new BehaviorSubject<PowerState | null>(null))
+    }
+    return this.powerStateStreams.get(deviceId)!
+  }
+
   featuresChanges(deviceId: string): Observable<AMTFeaturesResponse | null> {
     return this.getOrCreateFeaturesStream(deviceId).asObservable()
+  }
+
+  powerStateChanges(deviceId: string): Observable<PowerState | null> {
+    return this.getOrCreatePowerStateStream(deviceId).asObservable()
   }
 
   private readonly translate = inject(TranslateService)
@@ -268,29 +278,33 @@ export class DevicesService {
 
   getAMTFeatures(guid: string): Observable<AMTFeaturesResponse> {
     return this.http.get<AMTFeaturesResponse>(`${environment.mpsServer}/api/v1/amt/features/${guid}`).pipe(
-      tap((features) => {
-        this.getOrCreateFeaturesStream(guid).next(features)
-        this.featuresTimestamps.set(guid, Date.now())
-      }),
+      tap((features) => this.getOrCreateFeaturesStream(guid).next(features)),
       catchError((err) => {
         throw err
       })
     )
   }
 
-  /**
-   * Returns cached AMT features immediately if they are fresher than ttlMs,
-   * otherwise falls back to a real HTTP call. Eliminates duplicate round-trips
-   * when the toolbar and KVM component both load features within the same session.
-   * TTL is read from environment.amtFeaturesCacheTtlMs (default 30 s, max 3 min).
-   */
-  getAMTFeaturesCached(guid: string, ttlMs = this.FEATURES_TTL_MS): Observable<AMTFeaturesResponse> {
+  // Returns the cached AMT features if any consumer has already loaded them for
+  // this device; otherwise joins an in-flight fetch (so the toolbar and general
+  // components' simultaneous ngOnInit calls share one HTTP round-trip) or starts
+  // a new one. Downstream tabs (KVM, SOL) always see the cached value when
+  // device-detail was already visited.
+  getAMTFeaturesCached(guid: string): Observable<AMTFeaturesResponse> {
     const cached = this.getOrCreateFeaturesStream(guid).value
-    const ts = this.featuresTimestamps.get(guid) ?? 0
-    if (cached !== null && Date.now() - ts < ttlMs) {
+    if (cached !== null) {
       return of(cached)
     }
-    return this.getAMTFeatures(guid)
+    const existing = this.featuresInflight.get(guid)
+    if (existing) {
+      return existing
+    }
+    const request = this.getAMTFeatures(guid).pipe(
+      finalize(() => this.featuresInflight.delete(guid)),
+      shareReplay({ bufferSize: 1, refCount: false })
+    )
+    this.featuresInflight.set(guid, request)
+    return request
   }
 
   getAlarmOccurrences(guid: string): Observable<IPSAlarmClockOccurrence[]> {
@@ -440,10 +454,33 @@ export class DevicesService {
 
   getPowerState(deviceId: string): Observable<PowerState> {
     return this.http.get<PowerState>(`${environment.mpsServer}/api/v1/amt/power/state/${deviceId}`).pipe(
+      tap((state) => this.getOrCreatePowerStateStream(deviceId).next(state)),
       catchError((err) => {
         throw err
       })
     )
+  }
+
+  // Returns the cached power state if the toolbar (or another consumer) has
+  // already fetched it for this device; otherwise joins an in-flight fetch or
+  // starts a new one. KVM's initial powered-on check hits the cache after the
+  // toolbar loads; the KVM session's own 15 s polling bypasses this and calls
+  // getPowerState directly to keep the mouse cursor from freezing.
+  getPowerStateCached(deviceId: string): Observable<PowerState> {
+    const cached = this.getOrCreatePowerStateStream(deviceId).value
+    if (cached !== null) {
+      return of(cached)
+    }
+    const existing = this.powerStateInflight.get(deviceId)
+    if (existing) {
+      return existing
+    }
+    const request = this.getPowerState(deviceId).pipe(
+      finalize(() => this.powerStateInflight.delete(deviceId)),
+      shareReplay({ bufferSize: 1, refCount: false })
+    )
+    this.powerStateInflight.set(deviceId, request)
+    return request
   }
 
   getStats(): Observable<DeviceStats> {

--- a/src/app/devices/general/general.component.spec.ts
+++ b/src/app/devices/general/general.component.spec.ts
@@ -25,6 +25,7 @@ describe('GeneralComponent', () => {
       'getPowerState',
       'getAMTVersion',
       'getAMTFeatures',
+      'getAMTFeaturesCached',
       'getGeneralSettings',
       'PowerStates',
       'sendPowerAction',
@@ -33,28 +34,28 @@ describe('GeneralComponent', () => {
       'sendBulkDeactivate',
       'getWsmanOperations'
     ])
-    devicesServiceSpy.getAMTFeatures.and.returnValue(
-      of({
-        userConsent: 'ALL',
-        KVM: true,
-        SOL: true,
-        IDER: true,
-        redirection: true,
-        optInState: 1,
-        kvmAvailable: true,
-        httpsBootSupported: true,
-        ocr: true,
-        winREBootSupported: true,
-        localPBABootSupported: true,
-        remoteErase: true,
-        pbaBootFilesPath: [],
-        winREBootFilesPath: {
-          instanceID: '',
-          biosBootString: '',
-          bootString: ''
-        }
-      })
-    )
+    const amtFeaturesResponse = {
+      userConsent: 'ALL',
+      KVM: true,
+      SOL: true,
+      IDER: true,
+      redirection: true,
+      optInState: 1,
+      kvmAvailable: true,
+      httpsBootSupported: true,
+      ocr: true,
+      winREBootSupported: true,
+      localPBABootSupported: true,
+      remoteErase: true,
+      pbaBootFilesPath: [],
+      winREBootFilesPath: {
+        instanceID: '',
+        biosBootString: '',
+        bootString: ''
+      }
+    }
+    devicesServiceSpy.getAMTFeatures.and.returnValue(of(amtFeaturesResponse))
+    devicesServiceSpy.getAMTFeaturesCached.and.returnValue(of(amtFeaturesResponse))
     devicesServiceSpy.getGeneralSettings.and.returnValue(of({}))
     devicesServiceSpy.getAMTVersion.and.returnValue(of(['']))
     TestBed.configureTestingModule({

--- a/src/app/devices/general/general.component.ts
+++ b/src/app/devices/general/general.component.ts
@@ -98,7 +98,9 @@ export class GeneralComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     forkJoin({
-      amtFeatures: this.devicesService.getAMTFeatures(this.deviceId()).pipe(
+      // Reuses the toolbar's in-flight / cached features fetch so device-detail
+      // entry costs one /features round-trip total, not two.
+      amtFeatures: this.devicesService.getAMTFeaturesCached(this.deviceId()).pipe(
         catchError((err) => {
           const msg: string = this.translate.instant('general.errorAMTFeatures.value')
           this.snackBar.open(msg, undefined, SnackbarDefaults.defaultError)

--- a/src/app/devices/kvm/kvm.component.spec.ts
+++ b/src/app/devices/kvm/kvm.component.spec.ts
@@ -23,8 +23,10 @@ describe('KvmComponent', () => {
   let authServiceStub: any
   let setAmtFeaturesSpy: jasmine.Spy
   let getPowerStateSpy: jasmine.Spy
+  let getPowerStateCachedSpy: jasmine.Spy
   let getRedirectionStatusSpy: jasmine.Spy
   let getAMTFeaturesSpy: jasmine.Spy
+  let getAMTFeaturesCachedSpy: jasmine.Spy
   let sendPowerActionSpy: jasmine.Spy
   let tokenSpy: jasmine.Spy
   let getDisplaySelectionSpy: jasmine.Spy
@@ -43,8 +45,10 @@ describe('KvmComponent', () => {
       'sendPowerAction',
       'getDevice',
       'getPowerState',
+      'getPowerStateCached',
       'setAmtFeatures',
       'getAMTFeatures',
+      'getAMTFeaturesCached',
       'reqUserConsentCode',
       'cancelUserConsentCode',
       'getRedirectionExpirationToken',
@@ -79,28 +83,28 @@ describe('KvmComponent', () => {
         }
       })
     )
-    getAMTFeaturesSpy = devicesService.getAMTFeatures.and.returnValue(
-      of({
-        userConsent: 'none',
-        KVM: true,
-        SOL: true,
-        IDER: true,
-        redirection: true,
-        kvmAvailable: true,
-        optInState: 0,
-        httpsBootSupported: true,
-        ocr: true,
-        winREBootSupported: true,
-        localPBABootSupported: true,
-        remoteErase: true,
-        pbaBootFilesPath: [],
-        winREBootFilesPath: {
-          instanceID: '',
-          biosBootString: '',
-          bootString: ''
-        }
-      })
-    )
+    const amtFeaturesResponse = {
+      userConsent: 'none',
+      KVM: true,
+      SOL: true,
+      IDER: true,
+      redirection: true,
+      kvmAvailable: true,
+      optInState: 0,
+      httpsBootSupported: true,
+      ocr: true,
+      winREBootSupported: true,
+      localPBABootSupported: true,
+      remoteErase: true,
+      pbaBootFilesPath: [],
+      winREBootFilesPath: {
+        instanceID: '',
+        biosBootString: '',
+        bootString: ''
+      }
+    }
+    getAMTFeaturesSpy = devicesService.getAMTFeatures.and.returnValue(of(amtFeaturesResponse))
+    getAMTFeaturesCachedSpy = devicesService.getAMTFeaturesCached.and.returnValue(of(amtFeaturesResponse))
     devicesService.getDevice.and.returnValue(
       of({
         hostname: 'test-hostname',
@@ -119,6 +123,7 @@ describe('KvmComponent', () => {
       of({ isKVMConnected: false, isSOLConnected: false, isIDERConnected: false })
     )
     getPowerStateSpy = devicesService.getPowerState.and.returnValue(of({ powerstate: 2 }))
+    getPowerStateCachedSpy = devicesService.getPowerStateCached.and.returnValue(of({ powerstate: 2 }))
     sendPowerActionSpy = devicesService.sendPowerAction.and.returnValue(of({} as any))
     tokenSpy = devicesService.getRedirectionExpirationToken.and.returnValue(of({ token: '123' }))
     getDisplaySelectionSpy = devicesService.getDisplaySelection.and.returnValue(
@@ -213,16 +218,31 @@ describe('KvmComponent', () => {
     expect(component).toBeTruthy()
     fixture.detectChanges()
     expect(tokenSpy).toHaveBeenCalled()
-    expect(getPowerStateSpy).toHaveBeenCalled()
-    expect(getAMTFeaturesSpy).toHaveBeenCalled()
+    // init() reads power state and AMT features from the service cache so the
+    // toolbar/general fetches are not duplicated when the user lands on the KVM tab.
+    expect(getPowerStateCachedSpy).toHaveBeenCalled()
+    expect(getAMTFeaturesCachedSpy).toHaveBeenCalled()
+    expect(getPowerStateSpy).not.toHaveBeenCalled()
+    expect(getAMTFeaturesSpy).not.toHaveBeenCalled()
     expect(getRedirectionStatusSpy).toHaveBeenCalled()
-    expect(getDisplaySelectionSpy).toHaveBeenCalled()
+    // Display selection is deferred until the KVM session is actually connected
+    // so it doesn't compete with the relay websocket upgrade on the MPS queue.
+    expect(getDisplaySelectionSpy).not.toHaveBeenCalled()
+  })
+  it('loads displays once the KVM session reports connected (event=2)', () => {
+    fixture.detectChanges()
+    getDisplaySelectionSpy.calls.reset()
+    component.deviceKVMStatus(2)
+    expect(getDisplaySelectionSpy).toHaveBeenCalledTimes(1)
+    // Further connected events on the same session must not refetch
+    component.deviceKVMStatus(2)
+    expect(getDisplaySelectionSpy).toHaveBeenCalledTimes(1)
   })
   it('should have correct state on connect/disconnect methods', () => {
     // Initial state should be disconnected since we changed to signal(false)
     expect(component.deviceKVMConnection()).toBeFalsy()
 
-    // Test connect method — resets state, refreshes token, then re-establishes via init()
+    // Test connect method
     component.readyToLoadKvm = true
     component.connect()
     expect(component.isDisconnecting).toBeFalsy()
@@ -249,12 +269,12 @@ describe('KvmComponent', () => {
     expect(readyToLoadKvmAtStartOfInit).toBeFalse()
     expect(connectionAtStartOfInit).toBeFalse()
   })
-  it('connect() refreshes auth token via getRedirectionExpirationToken before calling init', () => {
+  it('connect() prefetches the auth token in parallel with init() for a reconnect', () => {
     tokenSpy.calls.reset()
-    spyOn(component, 'init')
+    const initSpy = spyOn(component, 'init')
     component.connect()
+    expect(initSpy).toHaveBeenCalledTimes(1)
     expect(tokenSpy).toHaveBeenCalledTimes(1)
-    expect(component.authToken()).toBe('123')
   })
   it('should not show error and hide loading when isDisconnecting is true', () => {
     component.isDisconnecting = true
@@ -312,6 +332,38 @@ describe('KvmComponent', () => {
     component.postUserConsentDecision(true).subscribe(() => {
       expect(component.loadingStatus()).toBe('kvm.status.connectingKVM.value')
       expect(component.deviceKVMConnection()).toBeTrue()
+      done()
+    })
+  })
+  it('refreshes the auth token before initiating connection (prevents stale-token after consent dialog)', (done) => {
+    tokenSpy.calls.reset()
+    tokenSpy.and.returnValue(of({ token: 'post-consent-token' }))
+    component.authToken.set('stale')
+    component.postUserConsentDecision(true).subscribe(() => {
+      expect(tokenSpy).toHaveBeenCalledWith('')
+      expect(component.authToken()).toBe('post-consent-token')
+      expect(component.deviceKVMConnection()).toBeTrue()
+      done()
+    })
+  })
+  it('skips the token refresh when init() completed fast (no blocking dialog)', (done) => {
+    tokenSpy.calls.reset()
+    component.authToken.set('prefetched-token')
+    ;(component as any).initStartTime = Date.now()
+    component.postUserConsentDecision(true).subscribe(() => {
+      expect(tokenSpy).not.toHaveBeenCalled()
+      expect(component.authToken()).toBe('prefetched-token')
+      expect(component.deviceKVMConnection()).toBeTrue()
+      expect(component.loadingStatus()).toBe('kvm.status.connectingKVM.value')
+      done()
+    })
+  })
+  it('does not refresh the auth token when consent is denied', (done) => {
+    tokenSpy.calls.reset()
+    component.authToken.set('untouched')
+    component.postUserConsentDecision(false).subscribe(() => {
+      expect(tokenSpy).not.toHaveBeenCalled()
+      expect(component.authToken()).toBe('untouched')
       done()
     })
   })
@@ -384,6 +436,23 @@ describe('KvmComponent', () => {
       }
     })
   })
+  it('getAMTFeaturesCached delegates to the service cache variant', (done) => {
+    component.getAMTFeaturesCached().subscribe(() => {
+      expect(getAMTFeaturesCachedSpy).toHaveBeenCalledWith('')
+      expect(getAMTFeaturesSpy).not.toHaveBeenCalled()
+      expect(component.isLoading()).toBeTrue()
+      done()
+    })
+  })
+  it('postUserConsentDecision does not issue a duplicate AMT features fetch', (done) => {
+    getAMTFeaturesSpy.calls.reset()
+    getAMTFeaturesCachedSpy.calls.reset()
+    component.postUserConsentDecision(true).subscribe(() => {
+      expect(getAMTFeaturesSpy).not.toHaveBeenCalled()
+      expect(getAMTFeaturesCachedSpy).not.toHaveBeenCalled()
+      done()
+    })
+  })
   it('should call getRedirectionStatus and return expected data', (done) => {
     component.getRedirectionStatus('test-guid').subscribe((response) => {
       expect(devicesService.getRedirectionStatus).toHaveBeenCalledWith('test-guid')
@@ -418,6 +487,13 @@ describe('KvmComponent', () => {
   it('getPowerState', async () => {
     component.getPowerState('111')
     expect(getPowerStateSpy).toHaveBeenCalled()
+  })
+  it('getPowerStateCached delegates to the service cache variant', async () => {
+    getPowerStateSpy.calls.reset()
+    getPowerStateCachedSpy.calls.reset()
+    component.getPowerStateCached('111').subscribe()
+    expect(getPowerStateCachedSpy).toHaveBeenCalledWith('111')
+    expect(getPowerStateSpy).not.toHaveBeenCalled()
   })
   xit('getPowerState error', (done: any) => {
     component.isLoading.set(true)

--- a/src/app/devices/kvm/kvm.component.ts
+++ b/src/app/devices/kvm/kvm.component.ts
@@ -101,6 +101,11 @@ export class KvmComponent implements OnInit, OnDestroy {
 
   private powerState: any = 0
   private timeInterval!: any
+  private initStartTime = 0
+  private displaysLoaded = false
+  // If init() completes faster than this, we assume no blocking dialog was
+  // shown and the token fetched in ngOnInit is still valid.
+  private readonly REDIR_TOKEN_REFRESH_THRESHOLD_MS = environment.redirTokenRefreshThresholdMs ?? 5_000
 
   public encodings = [
     { value: 1, viewValue: 'RLE 8' },
@@ -160,14 +165,7 @@ export class KvmComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.devicesService
-      .getRedirectionExpirationToken(this.deviceId())
-      .pipe(
-        tap((result) => {
-          this.authToken.set(result.token)
-        })
-      )
-      .subscribe()
+    this.prefetchAuthToken()
 
     // we need to get power state every 15 seconds to keep the KVM/mouse from freezing
     this.timeInterval = interval(15000)
@@ -183,8 +181,57 @@ export class KvmComponent implements OnInit, OnDestroy {
     this.init()
   }
 
+  // Prefetch a redirection token in parallel with init() so the fast path (no
+  // blocking dialogs) doesn't pay a round-trip in postUserConsentDecision.
+  private prefetchAuthToken(): void {
+    this.devicesService
+      .getRedirectionExpirationToken(this.deviceId())
+      .pipe(tap((result) => this.authToken.set(result.token)))
+      .subscribe()
+  }
+
   init(): void {
+    this.initStartTime = Date.now()
     this.isLoading.set(true)
+    // Kick off the connection chain first so its AMT round-trips aren't queued
+    // behind the display-selection fetch. The display list is non-critical for
+    // opening the KVM session and populates the dropdown in parallel.
+    this.loadingStatus.set('kvm.status.checkingPowerState.value')
+    this.getPowerStateCached(this.deviceId())
+      .pipe(
+        tap(() => this.loadingStatus.set('kvm.status.checkingRedirection.value')),
+        switchMap((powerState) => this.handlePowerState(powerState)),
+        switchMap((result) => (result === null ? of() : this.getRedirectionStatus(this.deviceId()))),
+        tap(() => this.loadingStatus.set('kvm.status.checkingAMTFeatures.value')),
+        switchMap((result: RedirectionStatus) => this.handleRedirectionStatus(result)),
+        switchMap((result) => (result === null ? of() : this.getAMTFeaturesCached())),
+        switchMap((results: AMTFeaturesResponse) => this.handleAMTFeaturesResponse(results)),
+        tap(() => this.loadingStatus.set('kvm.status.checkingConsent.value')),
+        switchMap((result: boolean | any) =>
+          iif(
+            () => result === false,
+            defer(() => of(null)),
+            defer(() => this.checkUserConsent())
+          )
+        ),
+        switchMap((result: any) =>
+          // safely convert null to undefined for type compatibility
+          this.userConsentService.handleUserConsentDecision(result, this.deviceId(), this.amtFeatures() ?? undefined)
+        ),
+        switchMap((result: any | UserConsentResponse) =>
+          this.userConsentService.handleUserConsentResponse(this.deviceId(), result, 'KVM')
+        ),
+        switchMap((result: any) => this.postUserConsentDecision(result)),
+        catchError((err) => {
+          this.isLoading.set(false)
+          this.loadingStatus.set('')
+          return throwError(() => err)
+        })
+      )
+      .subscribe()
+  }
+
+  private loadDisplaySelection(): void {
     this.devicesService.getDisplaySelection(this.deviceId()).subscribe({
       next: (result: DisplaySelectionResponse) => {
         const displays = result?.displays ?? []
@@ -216,57 +263,37 @@ export class KvmComponent implements OnInit, OnDestroy {
         this.selectedDisplay.set(0)
       }
     })
-    // device needs to be powered on in order to start KVM session
-    this.loadingStatus.set('kvm.status.checkingPowerState.value')
-    this.getPowerState(this.deviceId())
-      .pipe(
-        tap(() => this.loadingStatus.set('kvm.status.checkingRedirection.value')),
-        switchMap((powerState) => this.handlePowerState(powerState)),
-        switchMap((result) => (result === null ? of() : this.getRedirectionStatus(this.deviceId()))),
-        tap(() => this.loadingStatus.set('kvm.status.checkingAMTFeatures.value')),
-        switchMap((result: RedirectionStatus) => this.handleRedirectionStatus(result)),
-        switchMap((result) => (result === null ? of() : this.getAMTFeatures())),
-        switchMap((results: AMTFeaturesResponse) => this.handleAMTFeaturesResponse(results)),
-        tap(() => this.loadingStatus.set('kvm.status.checkingConsent.value')),
-        switchMap((result: boolean | any) =>
-          iif(
-            () => result === false,
-            defer(() => of(null)),
-            defer(() => this.checkUserConsent())
-          )
-        ),
-        switchMap((result: any) =>
-          // safely convert null to undefined for type compatibility
-          this.userConsentService.handleUserConsentDecision(result, this.deviceId(), this.amtFeatures() ?? undefined)
-        ),
-        switchMap((result: any | UserConsentResponse) =>
-          this.userConsentService.handleUserConsentResponse(this.deviceId(), result, 'KVM')
-        ),
-        switchMap((result: any) => this.postUserConsentDecision(result)),
-        catchError((err) => {
-          this.isLoading.set(false)
-          this.loadingStatus.set('')
-          return throwError(() => err)
-        })
-      )
-      .subscribe()
   }
 
   postUserConsentDecision(result: boolean): Observable<any> {
-    if (result !== false) {
-      // If result is true OR null (no consent needed), proceed with connection
-      this.readyToLoadKvm = this.amtFeatures()?.kvmAvailable ?? false
-      // Auto-connect - ensure connection state is properly set
-      this.isDisconnecting = false
-      this.loadingStatus.set('kvm.status.connectingKVM.value')
-      this.deviceKVMConnection.set(true)
-      this.getAMTFeatures()
-    } else {
+    if (result === false) {
       this.isLoading.set(false)
       this.loadingStatus.set('')
       this.deviceState.set(0)
+      return of(null)
     }
-    return of(null)
+    // If no dialog blocked the init() chain long enough to expire the token
+    // prefetched in ngOnInit, skip the refresh round-trip and use it directly.
+    const elapsedMs = Date.now() - this.initStartTime
+    if (elapsedMs < this.REDIR_TOKEN_REFRESH_THRESHOLD_MS && this.authToken()) {
+      this.readyToLoadKvm = this.amtFeatures()?.kvmAvailable ?? false
+      this.isDisconnecting = false
+      this.loadingStatus.set('kvm.status.connectingKVM.value')
+      this.deviceKVMConnection.set(true)
+      return of(null)
+    }
+    // The init() chain was blocked on a dialog long enough that the prefetched
+    // token may have expired. Refresh it so <amt-kvm> opens the websocket with
+    // a fresh token.
+    return this.devicesService.getRedirectionExpirationToken(this.deviceId()).pipe(
+      tap((token) => {
+        this.authToken.set(token.token)
+        this.readyToLoadKvm = this.amtFeatures()?.kvmAvailable ?? false
+        this.isDisconnecting = false
+        this.loadingStatus.set('kvm.status.connectingKVM.value')
+        this.deviceKVMConnection.set(true)
+      })
+    )
   }
 
   private handleKeyboardEventCapture = (event: KeyboardEvent): void => {
@@ -315,15 +342,9 @@ export class KvmComponent implements OnInit, OnDestroy {
     this.deviceState.set(-1)
     this.readyToLoadKvm = false
     this.deviceKVMConnection.set(false)
-    // Refresh the auth token before reconnecting in case it has expired
-    this.devicesService
-      .getRedirectionExpirationToken(this.deviceId())
-      .pipe(
-        tap((result) => {
-          this.authToken.set(result.token)
-        })
-      )
-      .subscribe({ next: () => this.init() })
+    this.displaysLoaded = false
+    this.prefetchAuthToken()
+    this.init()
   }
   @HostListener('window:beforeunload')
   beforeUnloadHandler() {
@@ -415,6 +436,17 @@ export class KvmComponent implements OnInit, OnDestroy {
     )
   }
 
+  getPowerStateCached(guid: string): Observable<any> {
+    return this.devicesService.getPowerStateCached(guid).pipe(
+      catchError((err) => {
+        this.isLoading.set(false)
+        const msg: string = this.translate.instant('kvm.errorRetrieve.value')
+        this.displayError(msg)
+        return throwError(() => err)
+      })
+    )
+  }
+
   handleAMTFeaturesResponse(results: AMTFeaturesResponse): Observable<any> {
     this.amtFeatures.set(results)
 
@@ -455,6 +487,11 @@ export class KvmComponent implements OnInit, OnDestroy {
   getAMTFeatures(): Observable<AMTFeaturesResponse> {
     this.isLoading.set(true)
     return this.devicesService.getAMTFeatures(this.deviceId())
+  }
+
+  getAMTFeaturesCached(): Observable<AMTFeaturesResponse> {
+    this.isLoading.set(true)
+    return this.devicesService.getAMTFeaturesCached(this.deviceId())
   }
 
   enableKvmDialog(): Observable<any> {
@@ -514,6 +551,11 @@ export class KvmComponent implements OnInit, OnDestroy {
     if (event === 2) {
       this.isLoading.set(false)
       this.loadingStatus.set('')
+      // Load the display list now that the websocket is up
+      if (!this.displaysLoaded) {
+        this.displaysLoaded = true
+        this.loadDisplaySelection()
+      }
     } else if (event === 0) {
       this.isLoading.set(false)
       this.loadingStatus.set('')

--- a/src/environments/environment.enterprise.dev.ts
+++ b/src/environments/environment.enterprise.dev.ts
@@ -10,7 +10,7 @@ export const environment = {
   mpsServer: 'http://localhost:8181',
   rpsServer: 'http://localhost:8181',
   vault: '',
-  amtFeaturesCacheTtlMs: 30_000, // 30 s default; max 3 min (180_000)
+  redirTokenRefreshThresholdMs: 5_000,
   auth: {
     clientId: '##CLIENTID##',
     issuer: '##ISSUER##',

--- a/src/environments/environment.enterprise.ts
+++ b/src/environments/environment.enterprise.ts
@@ -10,7 +10,7 @@ export const environment = {
   mpsServer: '##CONSOLE_SERVER_API##',
   rpsServer: '##CONSOLE_SERVER_API##',
   vault: '##VAULT_SERVER##',
-  amtFeaturesCacheTtlMs: 30_000, // 30 s default; max 3 min (180_000)
+  redirTokenRefreshThresholdMs: 5_000,
   auth: {
     clientId: '##CLIENTID##',
     issuer: '##ISSUER##',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -10,6 +10,6 @@ export const environment = {
   mpsServer: '##MPS_SERVER##',
   rpsServer: '##RPS_SERVER##',
   vault: '##VAULT_SERVER##',
-  amtFeaturesCacheTtlMs: 30_000, // 30 s default; max 3 min (180_000)
+  redirTokenRefreshThresholdMs: 5_000,
   auth: {}
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,7 +14,7 @@ export const environment = {
   mpsServer: 'http://localhost:3000',
   rpsServer: 'http://localhost:8081',
   vault: 'http://localhost/vault',
-  amtFeaturesCacheTtlMs: 30_000, // 30 s default; max 3 min (180_000)
+  redirTokenRefreshThresholdMs: 5_000,
   auth: {
     clientId: '',
     issuer: '',


### PR DESCRIPTION
This PR uses existing data from already completed API calls. Only a full refresh will cause KVM Connection to re-fetch power status, and amt features.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
