### PR TITLE
fix: allow editing profile without re-entering passwords

### DIFF
--- a/src/app/profiles/profile-detail/profile-detail.component.html
+++ b/src/app/profiles/profile-detail/profile-detail.component.html
@@ -80,7 +80,7 @@
             formControlName="amtPassword"
             matInput
             name="amtPassword"
-            required
+            [required]="!isEdit()"
             minlength="8"
             maxlength="32" />
           <mat-error>{{ 'fieldRequired.long.value' | translate }}</mat-error>
@@ -122,7 +122,7 @@
             [type]="mebxInputType()"
             matInput
             formControlName="mebxPassword"
-            required
+            [required]="!isEdit()"
             minlength="8"
             maxlength="32" />
           <mat-error>{{ 'fieldRequired.long.value' | translate }}</mat-error>

--- a/src/app/profiles/profile-detail/profile-detail.component.spec.ts
+++ b/src/app/profiles/profile-detail/profile-detail.component.spec.ts
@@ -7,6 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { ActivatedRoute, RouterModule } from '@angular/router'
 import { MatDialog } from '@angular/material/dialog'
+import { Validators } from '@angular/forms'
 import { of, throwError } from 'rxjs'
 import { ConfigsService } from '../../configs/configs.service'
 import { WirelessService } from '../../wireless/wireless.service'
@@ -154,15 +155,25 @@ describe('ProfileDetailComponent', () => {
     expect(wirelessGetDataSpy).toHaveBeenCalled()
     expect(proxyGetDataSpy).toHaveBeenCalled()
   })
-  it('should set connectionMode to TLS when tlsMode is not null', () => {
+  it('should set connectionMode to TLS when tlsMode is a TLS mode (1-4)', () => {
     const profile: Profile = { tlsMode: 4, ciraConfigName: 'config1' } as any
     component.setConnectionMode(profile)
     expect(component.profileForm.controls.connectionMode.value).toBe('TLS')
   })
-  it('should set connectionMode to CIRA when ciraConfigName is not null', () => {
+  it('should set connectionMode to CIRA when ciraConfigName is set and tlsMode is not a TLS mode', () => {
     const profile: Profile = { ciraConfigName: 'config1' } as any
     component.setConnectionMode(profile)
     expect(component.profileForm.controls.connectionMode.value).toBe('CIRA')
+  })
+  it('should set connectionMode to DIRECT when tlsMode is 0 and no CIRA config', () => {
+    const profile: Profile = { tlsMode: 0, ciraConfigName: null } as any
+    component.setConnectionMode(profile)
+    expect(component.profileForm.controls.connectionMode.value).toBe('DIRECT')
+  })
+  it('should set connectionMode to DIRECT when tlsMode is null and no CIRA config', () => {
+    const profile: Profile = { tlsMode: null, ciraConfigName: null } as any
+    component.setConnectionMode(profile)
+    expect(component.profileForm.controls.connectionMode.value).toBe('DIRECT')
   })
   it('should cancel', async () => {
     const routerSpy = spyOn(component.router, 'navigate')
@@ -218,6 +229,51 @@ describe('ProfileDetailComponent', () => {
 
     expect(profileUpdateSpy).toHaveBeenCalled()
     expect(routerSpy).toHaveBeenCalled()
+  })
+
+  it('should not require passwords on update', () => {
+    component.profileForm.patchValue({
+      activation: 'acmactivate',
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false
+    })
+
+    expect(component.profileForm.controls.amtPassword.hasValidator(Validators.required)).toBeFalse()
+    expect(component.profileForm.controls.mebxPassword.hasValidator(Validators.required)).toBeFalse()
+  })
+
+  it('should omit empty passwords from the update payload', () => {
+    const routerSpy = spyOn(component.router, 'navigate')
+
+    component.profileForm.patchValue({
+      profileName: 'profile',
+      activation: 'acmactivate',
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      amtPassword: '',
+      mebxPassword: '',
+      dhcpEnabled: true,
+      ciraConfigName: 'config1'
+    })
+    component.confirm()
+
+    expect(routerSpy).toHaveBeenCalled()
+    expect(profileUpdateSpy).toHaveBeenCalled()
+    const payload = profileUpdateSpy.calls.mostRecent().args[0]
+    expect(payload.amtPassword).toBeUndefined()
+    expect(payload.mebxPassword).toBeUndefined()
+  })
+
+  it('should require passwords on create', () => {
+    component.isEdit.set(false)
+    component.profileForm.patchValue({
+      activation: 'acmactivate',
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false
+    })
+
+    expect(component.profileForm.controls.amtPassword.hasValidator(Validators.required)).toBeTrue()
+    expect(component.profileForm.controls.mebxPassword.hasValidator(Validators.required)).toBeTrue()
   })
   it('should submit when valid (create)', () => {
     const routerSpy = spyOn(component.router, 'navigate')

--- a/src/app/profiles/profile-detail/profile-detail.component.ts
+++ b/src/app/profiles/profile-detail/profile-detail.component.ts
@@ -232,10 +232,21 @@ export class ProfileDetailComponent implements OnInit {
   }
 
   setConnectionMode(data: Profile): void {
-    if (data.tlsMode != null) {
+    if (data.tlsMode != null && data.tlsMode > 0) {
       this.profileForm.controls.connectionMode.setValue(this.connectionMode.tls)
     } else if (data.ciraConfigName != null) {
       this.profileForm.controls.connectionMode.setValue(this.connectionMode.cira)
+    } else {
+      this.profileForm.controls.connectionMode.setValue(this.connectionMode.direct)
+    }
+  }
+
+  // Passwords are optional on edit (the GET response never returns them).
+  private setPasswordRequiredValidator(control: FormControl<string | null>): void {
+    if (this.isEdit()) {
+      control.clearValidators()
+    } else {
+      control.setValidators(Validators.required)
     }
   }
 
@@ -251,7 +262,7 @@ export class ProfileDetailComponent implements OnInit {
       this.profileForm.controls.generateRandomMEBxPassword.disable()
     } else {
       this.profileForm.controls.mebxPassword.enable()
-      this.profileForm.controls.mebxPassword.setValidators(Validators.required)
+      this.setPasswordRequiredValidator(this.profileForm.controls.mebxPassword)
       this.profileForm.controls.userConsent.enable()
       this.profileForm.controls.userConsent.setValidators(Validators.required)
       this.profileForm.controls.generateRandomMEBxPassword.enable()
@@ -344,7 +355,7 @@ export class ProfileDetailComponent implements OnInit {
       this.profileForm.controls.amtPassword.clearValidators()
     } else {
       this.profileForm.controls.amtPassword.enable()
-      this.profileForm.controls.amtPassword.setValidators(Validators.required)
+      this.setPasswordRequiredValidator(this.profileForm.controls.amtPassword)
     }
     this.profileForm.controls.amtPassword.updateValueAndValidity()
   }
@@ -356,7 +367,7 @@ export class ProfileDetailComponent implements OnInit {
       this.profileForm.controls.mebxPassword.clearValidators()
     } else if (this.profileForm.controls.activation.value === 'acmactivate') {
       this.profileForm.controls.mebxPassword.enable()
-      this.profileForm.controls.mebxPassword.setValidators(Validators.required)
+      this.setPasswordRequiredValidator(this.profileForm.controls.mebxPassword)
     }
     this.profileForm.controls.mebxPassword.updateValueAndValidity()
   }
@@ -646,6 +657,12 @@ export class ProfileDetailComponent implements OnInit {
 
     // Always include proxy configurations
     result.proxyConfigs = this.selectedProxyConfigs()
+
+    if (this.isEdit()) {
+      // Omit empty passwords so PATCH leaves the stored credentials untouched.
+      if (!result.amtPassword) delete result.amtPassword
+      if (!result.mebxPassword) delete result.mebxPassword
+    }
 
     const request = this.isEdit() ? this.profilesService.update(result) : this.profilesService.create(result)
 


### PR DESCRIPTION
The profile GET response does not return amtPassword or mebxPassword, so the edit form loads with both fields blank. Previously the required validators would block submit until the user re-typed them.

- Make amtPassword and mebxPassword required only on create.
- On edit, omit empty password fields from the PATCH payload so the stored (encrypted) credentials are left untouched.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
