### PR TITLE
fix(devices): bind WSMAN Explorer placeholder via property syntax

### DIFF
--- a/src/app/devices/explorer/explorer.component.html
+++ b/src/app/devices/explorer/explorer.component.html
@@ -6,7 +6,7 @@
         <mat-label>{{ 'explorer.WSMANCall.value' | translate }}</mat-label>
         <input
           type="text"
-          placeholder="'explorer.placeHolder.value' | translate"
+          [placeholder]="'explorer.placeHolder.value' | translate"
           matInput
           [formControl]="myControl"
           [matAutocomplete]="auto"


### PR DESCRIPTION
## Summary
- The WSMAN Explorer search field was rendering the literal string `'explorer.placeHolder.value' | translate` because the `placeholder` attribute was using string-attribute syntax instead of a property binding.
- Switched to `[placeholder]="..."` so Angular evaluates the `translate` pipe and the input shows the localized `Select...` prompt.

## Test plan
- [ ] `npm run lint` passes (verified locally).
- [ ] Open a device's **Explorer** view; confirm the search input now shows `Select...` as its placeholder.
- [ ] Click the input and confirm the WSMAN call autocomplete list opens as before.

Resolves: #3319