### PR TITLE
test: add Redfish Cypress test suites

### DIFF
--- a/cypress.redfish.config.ts
+++ b/cypress.redfish.config.ts
@@ -1,0 +1,107 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Cypress configuration for DMTF Redfish API tests only.
+ *
+ * Run with:
+ *   npx cypress run --config-file cypress.redfish.config.ts
+ *   npm run cy-runner:redfish
+ *   npm run cy-open:redfish
+ *
+ * These tests use cy.request() to call the Redfish API directly —
+ * no Angular UI is required to be running.
+ *
+ * Environment variables (override via CLI --env or .env file):
+ *   REDFISH_BASEURL   Base URL of the Redfish server (default: http://localhost:8181)
+ *   REDFISH_USERNAME  Admin username for Basic Auth  (default: standalone)
+ *   REDFISH_PASSWORD  Admin password for Basic Auth  (default: G@ppm0ym)
+ *   REDFISH_SYSTEM_ID UUID of a registered AMT device (optional).
+ *                     If empty/unset, Systems tests auto-detect the first
+ *                     member under /redfish/v1/Systems.
+ */
+
+import { defineConfig } from 'cypress'
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * All timestamps in this config are UTC (ISO 8601 with trailing "Z").
+ * This matches the UTC timestamps written by mocha-junit-reporter inside
+ * the XML <testsuite timestamp="..."> attribute, keeping everything consistent.
+ */
+
+/** UTC timestamp for log lines: "2026-02-27T07:11:51.381Z" */
+const utcTimestamp = (): string => new Date().toISOString()
+
+/** UTC timestamp safe for filenames: "2026-02-27T07-11-51Z" */
+const utcFileTimestamp = (): string =>
+  new Date()
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z')
+    .replace(/:/g, '-')
+
+export default defineConfig({
+  reporter: 'mocha-multi-reporters',
+  reporterOptions: {
+    reporterEnabled: 'cypress/support/custom-reporter.js, mocha-junit-reporter',
+    cypressSupportCustomReporterJsReporterOptions: {
+      reportDir: 'cypress/reports',
+      reportName: 'cypress-redfish-test-report'
+    },
+    mochaJunitReporterReporterOptions: {
+      mochaFile: `cypress-redfish-api-test-output-${utcFileTimestamp()}-[hash].xml`,
+      toConsole: false
+    }
+  },
+  viewportWidth: 1280,
+  viewportHeight: 720,
+  projectId: 'mxeztq',
+
+  env: {
+    // Base URL of the Redfish server (matches Postman test environment port)
+    REDFISH_BASEURL: 'https://localhost:8181',
+    // Credentials for Basic Auth and POST /redfish/v1/SessionService/Sessions
+    REDFISH_USERNAME: 'standalone',
+    REDFISH_PASSWORD: 'G@ppm0ym',
+    // Optional: a real registered AMT device UUID for Systems tests.
+    // If empty, tests auto-detect the first member under /redfish/v1/Systems.
+    REDFISH_SYSTEM_ID: ''
+  },
+
+  // API-only tests: no browser launch strictly needed, but Cypress still
+  // requires a browser context. Tests run headlessly via electron.
+  chromeWebSecurity: false,
+  // Allow self-signed TLS certificates from the console backend
+  rejectUnauthorized: false,
+
+  e2e: {
+    setupNodeEvents(on) {
+      // Create a timestamped log file under cypress/logs/ for functional test runs.
+      // The file is written in real-time so you can `tail -f` it during a run.
+      // cypress/logs/*.log is covered by the *.log entry in .gitignore.
+      const logsDir = path.join(__dirname, 'cypress', 'logs')
+      if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true })
+      const logFile = path.join(logsDir, `redfish-functional-${utcFileTimestamp()}.log`)
+
+      on('task', {
+        log(message: string): null {
+          const line = `${utcTimestamp()}  ${message}`
+          process.stdout.write(line + '\n')
+          fs.appendFileSync(logFile, line + '\n', 'utf8')
+          return null
+        }
+      })
+    },
+    // Run specs under integration-redfish/ (alongside the original integration/ folder)
+    specPattern: 'cypress/e2e/integration-redfish/**/*.spec.ts',
+    supportFile: 'cypress/support/e2e.ts',
+    screenshotOnRunFailure: false,
+    // Longer timeouts for API calls that may hit real hardware
+    defaultCommandTimeout: 10000,
+    requestTimeout: 15000,
+    responseTimeout: 15000
+  }
+})

--- a/cypress.redfish.config.ts
+++ b/cypress.redfish.config.ts
@@ -18,6 +18,8 @@
  *   REDFISH_BASEURL   Base URL of the Redfish server (default: http://localhost:8181)
  *   REDFISH_USERNAME  Admin username for Basic Auth  (default: standalone)
  *   REDFISH_PASSWORD  Admin password for Basic Auth  (default: G@ppm0ym)
+ *   ISOLATE           Y to allow isolated/off-device fallback behavior, N for
+ *                     strict on-device assertions (default: Y)
  *   REDFISH_SYSTEM_ID UUID of a registered AMT device (optional).
  *                     If empty/unset, Systems tests auto-detect the first
  *                     member under /redfish/v1/Systems.
@@ -66,6 +68,8 @@ export default defineConfig({
     // Credentials for Basic Auth and POST /redfish/v1/SessionService/Sessions
     REDFISH_USERNAME: 'standalone',
     REDFISH_PASSWORD: 'G@ppm0ym',
+    // Y = isolated/off-device tolerant mode, N = strict on-device mode.
+    ISOLATE: 'Y',
     // Optional: a real registered AMT device UUID for Systems tests.
     // If empty, tests auto-detect the first member under /redfish/v1/Systems.
     REDFISH_SYSTEM_ID: ''

--- a/cypress/e2e/fixtures/api/redfish/serviceroot.ts
+++ b/cypress/e2e/fixtures/api/redfish/serviceroot.ts
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Fixtures for Redfish Service Root, OData metadata and OData service document tests.
+ * Covers: GET /redfish/v1/  |  GET /redfish/v1/$metadata  |  GET /redfish/v1/odata
+ */
+
+const servicerootFixtures = {
+  serviceRoot: {
+    success: {
+      response: {
+        '@odata.context': '/redfish/v1/$metadata#ServiceRoot.ServiceRoot',
+        '@odata.id': '/redfish/v1',
+        '@odata.type': '#ServiceRoot.v1_19_0.ServiceRoot',
+        Id: 'RootService',
+        Name: 'Root Service',
+        RedfishVersion: '1.19.0',
+        Systems: { '@odata.id': '/redfish/v1/Systems' },
+        SessionService: { '@odata.id': '/redfish/v1/SessionService' }
+      }
+    }
+  },
+
+  odata: {
+    success: {
+      response: {
+        '@odata.context': '/redfish/v1/$metadata#ServiceRoot.ServiceRoot',
+        value: [
+          { name: 'Systems', kind: 'Singleton', url: '/redfish/v1/Systems' },
+          { name: 'SessionService', kind: 'Singleton', url: '/redfish/v1/SessionService' }
+        ]
+      }
+    }
+  }
+}
+
+export { servicerootFixtures }

--- a/cypress/e2e/fixtures/api/redfish/session.ts
+++ b/cypress/e2e/fixtures/api/redfish/session.ts
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Fixtures for Redfish SessionService API tests.
+ * Covers: GET/PATCH/PUT /redfish/v1/SessionService
+ *         GET/POST      /redfish/v1/SessionService/Sessions
+ *         GET/DELETE    /redfish/v1/SessionService/Sessions/{SessionId}
+ *
+ * NOTE: Redfish session login uses { UserName, Password } (capital letters),
+ *       NOT { username, password } used by the proprietary /api/v1/authorize endpoint.
+ */
+
+const sessionFixtures = {
+  validCredentials: {
+    request: {
+      UserName: 'standalone',
+      Password: 'G@ppm0ym'
+    }
+  },
+
+  invalidCredentials: {
+    request: {
+      UserName: 'wronguser',
+      Password: 'wrongpass'
+    }
+  },
+
+  missingFields: {
+    request: {}
+  },
+
+  sessionService: {
+    success: {
+      response: {
+        '@odata.context': '/redfish/v1/$metadata#SessionService.SessionService',
+        '@odata.id': '/redfish/v1/SessionService',
+        '@odata.type': '#SessionService.v1_2_0.SessionService',
+        Id: 'SessionService',
+        Name: 'Session Service',
+        Sessions: { '@odata.id': '/redfish/v1/SessionService/Sessions' }
+      }
+    }
+  },
+
+  sessionCollection: {
+    success: {
+      response: {
+        '@odata.context': '/redfish/v1/$metadata#SessionCollection.SessionCollection',
+        '@odata.id': '/redfish/v1/SessionService/Sessions',
+        '@odata.type': '#SessionCollection.SessionCollection',
+        Name: 'Session Collection'
+      }
+    }
+  }
+}
+
+export { sessionFixtures }

--- a/cypress/e2e/fixtures/api/redfish/systems.ts
+++ b/cypress/e2e/fixtures/api/redfish/systems.ts
@@ -1,0 +1,107 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Fixtures for Redfish Computer Systems API tests.
+ * Covers: GET  /redfish/v1/Systems
+ *         GET  /redfish/v1/Systems/{ComputerSystemId}
+ *         PATCH /redfish/v1/Systems/{ComputerSystemId}
+ *         POST /redfish/v1/Systems/{ComputerSystemId}/Actions/ComputerSystem.Reset
+ *
+ * testSystemId matches the Postman test environment system_id value.
+ * Override at runtime with the REDFISH_SYSTEM_ID Cypress environment variable.
+ */
+
+const TEST_SYSTEM_ID = '550e8400-e29b-41d4-a716-446655440001'
+const NON_EXISTENT_SYSTEM_ID = '00000000-0000-0000-0000-000000000000'
+
+const systemsFixtures = {
+  testSystemId: TEST_SYSTEM_ID,
+  nonExistentSystemId: NON_EXISTENT_SYSTEM_ID,
+
+  collection: {
+    success: {
+      response: {
+        '@odata.context': '/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection',
+        '@odata.id': '/redfish/v1/Systems',
+        '@odata.type': '#ComputerSystemCollection.ComputerSystemCollection',
+        Name: 'Computer System Collection'
+      }
+    }
+  },
+
+  // Valid enum values per DMTF Redfish specification
+  validPowerStates: [
+    'On',
+    'Off',
+    'PoweringOn',
+    'PoweringOff'
+  ],
+  validSystemTypes: [
+    'Physical',
+    'Virtual',
+    'OS',
+    'PhysicallyPartitioned',
+    'VirtuallyPartitioned'
+  ],
+  validStatusStates: [
+    'Enabled',
+    'Disabled',
+    'StandbyOffline',
+    'StandbySpare',
+    'InTest',
+    'Starting',
+    'Absent',
+    'UnavailableOffline',
+    'Deferring',
+    'Quiesced',
+    'Updating',
+    'Degraded'
+  ],
+  validHealthValues: [
+    'OK',
+    'Warning',
+    'Critical'
+  ],
+  validMemoryMirroring: [
+    'System',
+    'DIMM',
+    'Hybrid',
+    'None'
+  ],
+
+  reset: {
+    // All ResetTypes supported by the implementation
+    request: { ResetType: 'GracefulShutdown' },
+    on: { ResetType: 'On' },
+    forceOff: { ResetType: 'ForceOff' },
+    forceRestart: { ResetType: 'ForceRestart' },
+    gracefulRestart: { ResetType: 'GracefulRestart' },
+    powerCycle: { ResetType: 'PowerCycle' },
+    // Error cases
+    invalidResetType: { ResetType: 'NotARealResetType' },
+    missingResetType: {}
+  },
+
+  patchBootSettings: {
+    // Valid boot settings variants
+    request: {
+      Boot: { BootSourceOverrideEnabled: 'Once', BootSourceOverrideTarget: 'Pxe' }
+    },
+    biosSetup: {
+      Boot: { BootSourceOverrideEnabled: 'Once', BootSourceOverrideTarget: 'BiosSetup' }
+    },
+    empty: {},
+    // Invalid settings — should return 400
+    invalidTarget: {
+      Boot: { BootSourceOverrideEnabled: 'Once', BootSourceOverrideTarget: 'InvalidBootTarget' }
+    },
+    invalidEnabled: {
+      Boot: { BootSourceOverrideEnabled: 'Always', BootSourceOverrideTarget: 'Pxe' }
+    }
+  }
+}
+
+export { systemsFixtures }

--- a/cypress/e2e/integration-redfish/helpers/redfish.ts
+++ b/cypress/e2e/integration-redfish/helpers/redfish.ts
@@ -1,0 +1,70 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Shared Redfish Cypress helpers for URL/auth and dynamic system selection.
+ */
+
+export const redfishUrl = (): string => Cypress.env('REDFISH_BASEURL') ?? 'http://localhost:8181'
+
+export const basicAuthHeaders = (): Record<string, string> => {
+  const username = (Cypress.env('REDFISH_USERNAME') as string) ?? 'standalone'
+  const password = (Cypress.env('REDFISH_PASSWORD') as string) ?? 'G@ppm0ym'
+  return { Authorization: `Basic ${btoa(`${username}:${password}`)}` }
+}
+
+const configuredSystemId = (): string | undefined => {
+  const raw = Cypress.env('REDFISH_SYSTEM_ID')
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+const extractSystemIdFromODataId = (odataId: string): string | undefined => {
+  const match = odataId.match(/\/redfish\/v1\/Systems\/([^/]+)$/)
+  return match?.[1]
+}
+
+/**
+ * Returns a `systemId()` getter backed by a `before()` hook:
+ * - If `REDFISH_SYSTEM_ID` is set, use it.
+ * - Otherwise call `/redfish/v1/Systems` and auto-select the first member.
+ * - Falls back to `fallbackSystemId` if discovery fails.
+ */
+export const createSystemIdResolver = (fallbackSystemId: string): (() => string) => {
+  let resolvedSystemId: string | undefined
+
+  before(() => {
+    const configured = configuredSystemId()
+    if (configured) {
+      resolvedSystemId = configured
+      cy.log(`Using REDFISH_SYSTEM_ID from environment: ${configured}`)
+      return
+    }
+
+    cy.request({
+      method: 'GET',
+      url: `${redfishUrl()}/redfish/v1/Systems`,
+      headers: basicAuthHeaders(),
+      failOnStatusCode: false
+    }).then((response) => {
+      if (response.status !== 200) {
+        resolvedSystemId = fallbackSystemId
+        cy.log(`System discovery failed (HTTP ${response.status}), fallback ID: ${resolvedSystemId}`)
+        return
+      }
+
+      const body = response.body as { Members?: { '@odata.id'?: string }[] }
+      const members = Array.isArray(body.Members) ? body.Members : []
+      const firstODataId = members.find((member) => typeof member?.['@odata.id'] === 'string')?.['@odata.id']
+      const discovered = typeof firstODataId === 'string' ? extractSystemIdFromODataId(firstODataId) : undefined
+
+      resolvedSystemId = discovered ?? fallbackSystemId
+      cy.log(`Auto-selected REDFISH_SYSTEM_ID: ${resolvedSystemId}`)
+    })
+  })
+
+  return (): string => resolvedSystemId ?? fallbackSystemId
+}

--- a/cypress/e2e/integration-redfish/helpers/redfish.ts
+++ b/cypress/e2e/integration-redfish/helpers/redfish.ts
@@ -15,6 +15,34 @@ export const basicAuthHeaders = (): Record<string, string> => {
   return { Authorization: `Basic ${btoa(`${username}:${password}`)}` }
 }
 
+const normalizedIsolationSwitch = (): string | undefined => {
+  const raw = Cypress.env('ISOLATE')
+
+  if (typeof raw === 'boolean') {
+    return raw ? 'Y' : 'N'
+  }
+
+  if (typeof raw !== 'string') {
+    return undefined
+  }
+
+  const normalized = raw.trim().toUpperCase()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+export const isIsolatedRun = (): boolean => normalizedIsolationSwitch() !== 'N'
+
+export const deviceAllowedStatuses = (
+  successStatuses: number | number[],
+  isolatedOnlyStatuses: number[] = []
+): number[] => {
+  const normalizedSuccessStatuses = Array.isArray(successStatuses) ? successStatuses : [successStatuses]
+
+  return isIsolatedRun()
+    ? Array.from(new Set([...normalizedSuccessStatuses, ...isolatedOnlyStatuses]))
+    : normalizedSuccessStatuses
+}
+
 const configuredSystemId = (): string | undefined => {
   const raw = Cypress.env('REDFISH_SYSTEM_ID')
   if (typeof raw !== 'string') return undefined
@@ -37,6 +65,7 @@ export const createSystemIdResolver = (fallbackSystemId: string): (() => string)
   let resolvedSystemId: string | undefined
 
   before(() => {
+    const isolatedRun = isIsolatedRun()
     const configured = configuredSystemId()
     if (configured) {
       resolvedSystemId = configured
@@ -51,6 +80,12 @@ export const createSystemIdResolver = (fallbackSystemId: string): (() => string)
       failOnStatusCode: false
     }).then((response) => {
       if (response.status !== 200) {
+        if (!isolatedRun) {
+          throw new Error(
+            `Non-isolated run requires GET /redfish/v1/Systems to return 200, received HTTP ${response.status}`
+          )
+        }
+
         resolvedSystemId = fallbackSystemId
         cy.log(`System discovery failed (HTTP ${response.status}), fallback ID: ${resolvedSystemId}`)
         return
@@ -61,7 +96,17 @@ export const createSystemIdResolver = (fallbackSystemId: string): (() => string)
       const firstODataId = members.find((member) => typeof member?.['@odata.id'] === 'string')?.['@odata.id']
       const discovered = typeof firstODataId === 'string' ? extractSystemIdFromODataId(firstODataId) : undefined
 
-      resolvedSystemId = discovered ?? fallbackSystemId
+      if (!discovered) {
+        if (!isolatedRun) {
+          throw new Error('Non-isolated run requires at least one system member under /redfish/v1/Systems')
+        }
+
+        resolvedSystemId = fallbackSystemId
+        cy.log(`System discovery returned no members, fallback ID: ${resolvedSystemId}`)
+        return
+      }
+
+      resolvedSystemId = discovered
       cy.log(`Auto-selected REDFISH_SYSTEM_ID: ${resolvedSystemId}`)
     })
   })

--- a/cypress/e2e/integration-redfish/serviceroot/serviceroot.spec.ts
+++ b/cypress/e2e/integration-redfish/serviceroot/serviceroot.spec.ts
@@ -1,0 +1,423 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Redfish Service Root, OData Metadata and OData Service Document API Tests
+ *
+ * Endpoints covered (all PUBLIC — no authentication required):
+ *   GET /redfish/v1/             Service Root (JSON)
+ *   GET /redfish/v1/$metadata    OData CSDL metadata document (XML)
+ *   GET /redfish/v1/odata        OData service document (JSON)
+ */
+
+import { httpCodes } from '../../fixtures/api/httpCodes'
+import { servicerootFixtures } from '../../fixtures/api/redfish/serviceroot'
+
+const redfishUrl = (): string => Cypress.env('REDFISH_BASEURL') ?? 'http://localhost:8181'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Service Root - GET /redfish/v1/', () => {
+  context(
+    'TC_SERVICEROOT_GET_WITHOUT_AUTH - public endpoint serves ServiceRoot document without authentication',
+    () => {
+      it('returns HTTP 200 with no authentication credentials', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+        })
+      })
+
+      it('returns content-type application/json and OData-Version 4.0 response header', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.headers['content-type']).to.include('application/json')
+          expect(response.headers['odata-version']).to.eq('4.0')
+        })
+      })
+
+      it('returns @odata.context, @odata.id, and @odata.type pointing to ServiceRoot', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body).to.have.property('@odata.context')
+          expect(response.body).to.have.property('@odata.id')
+          expect(response.body).to.have.property('@odata.type')
+          expect(response.body['@odata.type']).to.include('ServiceRoot')
+          expect(response.body['@odata.id']).to.be.oneOf(['/redfish/v1', '/redfish/v1/'])
+          // @odata.context must reference $metadata and ServiceRoot (Postman #3)
+          expect(response.body['@odata.context']).to.include('$metadata')
+          expect(response.body['@odata.context']).to.include('ServiceRoot')
+        })
+      })
+
+      it('returns Id, Name, RedfishVersion (semver), and UUID in the ServiceRoot body', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body).to.have.property('Id', servicerootFixtures.serviceRoot.success.response.Id)
+          expect(response.body).to.have.property('Name', servicerootFixtures.serviceRoot.success.response.Name)
+          expect(response.body).to.have.property('RedfishVersion')
+          expect(response.body.RedfishVersion).to.match(/^\d+\.\d+\.\d+$/)
+          expect(response.body).to.have.property('UUID')
+          expect(response.body.UUID).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+        })
+      })
+
+      it('contains Systems navigation link with @odata.id set to /redfish/v1/Systems', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body).to.have.property('Systems')
+          expect(response.body.Systems).to.have.property('@odata.id', '/redfish/v1/Systems')
+        })
+      })
+
+      it('contains SessionService navigation link with @odata.id set to /redfish/v1/SessionService', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body).to.have.property('SessionService')
+          expect(response.body.SessionService).to.have.property('@odata.id', '/redfish/v1/SessionService')
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/$metadata
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish OData Metadata - GET /redfish/v1/$metadata', () => {
+  context('TC_METADATA_GET_WITHOUT_AUTH - public endpoint serves OData CSDL metadata as application/xml', () => {
+    it('returns HTTP 200 with no authentication credentials', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/$metadata`,
+        failOnStatusCode: false,
+        headers: { Accept: 'application/xml' }
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+      })
+    })
+
+    it('returns content-type application/xml and OData-Version 4.0 response header', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/$metadata`,
+        failOnStatusCode: false,
+        headers: { Accept: 'application/xml' }
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.headers['content-type']).to.include('application/xml')
+        expect(response.headers['odata-version']).to.eq('4.0')
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/odata
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish OData Service Document - GET /redfish/v1/odata', () => {
+  context('TC_ODATA_GET_SERVICE_ENTRIES - public endpoint serves OData service document with entry list', () => {
+    it('returns HTTP 200 with no authentication credentials', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/odata`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+      })
+    })
+
+    it('returns content-type application/json response header', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/odata`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.headers['content-type']).to.include('application/json')
+      })
+    })
+
+    it('returns @odata.context and a non-empty value array of service entries', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/odata`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.body).to.have.property('@odata.context')
+        expect(response.body).to.have.property('value')
+        expect(response.body.value).to.be.an('array').and.have.length.gte(1)
+      })
+    })
+
+    it('each service entry has name, kind (Singleton or EntitySet), and url properties', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/odata`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        response.body.value.forEach((entry: { name: string; kind: string; url: string }) => {
+          expect(entry).to.have.property('name')
+          expect(entry.name).to.be.a('string').and.not.equal('')
+          expect(entry).to.have.property('kind')
+          expect(['Singleton', 'EntitySet']).to.include(entry.kind)
+          expect(entry).to.have.property('url')
+          expect(entry.url).to.include('/redfish/v1/')
+          expect(entry.url).to.not.include('$metadata')
+          expect(entry.url).to.not.include('/odata')
+        })
+      })
+    })
+
+    it('service entries in value array are sorted alphabetically by name', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/odata`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        const names = (response.body.value as { name: string }[]).map((e) => e.name)
+        const sorted = [...names].sort((a, b) => a.localeCompare(b))
+        expect(names).to.deep.equal(sorted)
+      })
+    })
+
+    it('includes Systems entry with kind Singleton and url /redfish/v1/Systems', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/odata`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        const systemsEntry = (response.body.value as { name: string; kind: string; url: string }[]).find(
+          (e) => e.name === 'Systems'
+        )
+        expect(systemsEntry).to.not.equal(undefined)
+        expect(systemsEntry?.kind).to.equal('Singleton')
+        expect(systemsEntry?.url).to.equal('/redfish/v1/Systems')
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1  (no trailing slash)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Service Root - No Trailing Slash', () => {
+  context(
+    'TC_SERVICEROOT_GET_NO_TRAILING_SLASH - GET /redfish/v1 without trailing slash returns 200 or redirect to /',
+    () => {
+      it('returns HTTP 200 or a 3xx redirect with Location pointing to /redfish/v1/', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1`,
+          failOnStatusCode: false,
+          followRedirect: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            200,
+            301,
+            302,
+            307,
+            308
+          ])
+          if (response.status === 200) {
+            expect(response.body).to.have.property('@odata.id')
+          }
+          if ([
+              301,
+              302,
+              307,
+              308
+            ].includes(response.status)) {
+            expect(response.headers['location']).to.include('/redfish/v1/')
+          }
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/$metadata — XML content assertions
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish OData Metadata - XML Content', () => {
+  context(
+    'TC_METADATA_XML_CONTENT_VALIDATION - EDMX document structure contains required namespace and schema references',
+    () => {
+      it('returns a non-empty string response body', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/$metadata`,
+          failOnStatusCode: false,
+          headers: { Accept: 'application/xml' }
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body).to.be.a('string').and.have.length.greaterThan(0)
+        })
+      })
+
+      it('contains XML declaration and edmx:Edmx root element with OASIS edmx namespace', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/$metadata`,
+          failOnStatusCode: false,
+          headers: { Accept: 'application/xml' }
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          const xml = response.body as string
+          expect(xml).to.include('<?xml version')
+          expect(xml).to.include('<edmx:Edmx')
+          expect(xml).to.include('http://docs.oasis-open.org/odata/ns/edmx')
+        })
+      })
+
+      it('contains ServiceRoot, ComputerSystem, and Resource namespace references', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/$metadata`,
+          failOnStatusCode: false,
+          headers: { Accept: 'application/xml' }
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          const xml = response.body as string
+          expect(xml).to.include('ServiceRoot')
+          expect(xml).to.include('ComputerSystem')
+          expect(xml).to.include('Resource')
+        })
+      })
+
+      it('contains edmx:Reference and edmx:DataServices structural elements', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/$metadata`,
+          failOnStatusCode: false,
+          headers: { Accept: 'application/xml' }
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          const xml = response.body as string
+          expect(xml).to.include('edmx:Reference')
+          expect(xml).to.include('edmx:DataServices')
+        })
+      })
+
+      it('returns identical body on repeated requests confirming idempotent response', () => {
+        let firstBody: string
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/$metadata`,
+          failOnStatusCode: false,
+          headers: { Accept: 'application/xml' }
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          firstBody = response.body as string
+        })
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/$metadata`,
+          failOnStatusCode: false,
+          headers: { Accept: 'application/xml' }
+        }).then((response) => {
+          expect(response.body).to.equal(firstBody)
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Method Not Allowed — /redfish/v1/  and  /redfish/v1/odata
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Service Root - Method Not Allowed', () => {
+  context(
+    'TC_SERVICEROOT_METHOD_NOT_ALLOWED - POST PUT PATCH DELETE on /redfish/v1/ return 405 Method Not Allowed',
+    () => {
+      const methodsNotAllowed = [
+        'POST',
+        'PUT',
+        'DELETE',
+        'PATCH'
+      ] as const
+
+      methodsNotAllowed.forEach((method) => {
+        it(`returns 405 for ${method} /redfish/v1/`, () => {
+          cy.request({
+            method,
+            url: `${redfishUrl()}/redfish/v1/`,
+            body: [
+              'POST',
+              'PUT',
+              'PATCH'
+            ].includes(method) ? {} : undefined,
+            failOnStatusCode: false
+          }).then((response) => {
+            expect(response.status).to.eq(405)
+            expect(response.headers['odata-version']).to.not.equal(undefined)
+            expect(response.body).to.have.property('error')
+          })
+        })
+      })
+    }
+  )
+})
+
+describe('Redfish OData Service Document - Method Not Allowed', () => {
+  context(
+    'TC_ODATA_METHOD_NOT_ALLOWED - POST PUT PATCH DELETE on /redfish/v1/odata return 405 Method Not Allowed',
+    () => {
+      const methodsNotAllowed = [
+        'POST',
+        'PUT',
+        'DELETE',
+        'PATCH'
+      ] as const
+
+      methodsNotAllowed.forEach((method) => {
+        it(`returns 405 for ${method} /redfish/v1/odata`, () => {
+          cy.request({
+            method,
+            url: `${redfishUrl()}/redfish/v1/odata`,
+            body: [
+              'POST',
+              'PUT',
+              'PATCH'
+            ].includes(method) ? {} : undefined,
+            failOnStatusCode: false
+          }).then((response) => {
+            expect(response.status).to.eq(405)
+            expect(response.headers['odata-version']).to.not.equal(undefined)
+            expect(response.body).to.have.property('error')
+          })
+        })
+      })
+    }
+  )
+})

--- a/cypress/e2e/integration-redfish/session/session.spec.ts
+++ b/cypress/e2e/integration-redfish/session/session.spec.ts
@@ -1,0 +1,484 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Redfish SessionService API Tests
+ *
+ * Endpoints covered:
+ *   GET    /redfish/v1/SessionService                             (auth required)
+ *   PATCH  /redfish/v1/SessionService                             (auth required)
+ *   PUT    /redfish/v1/SessionService                             (auth required)
+ *   GET    /redfish/v1/SessionService/Sessions                    (auth required)
+ *   POST   /redfish/v1/SessionService/Sessions                    (PUBLIC — login)
+ *   GET    /redfish/v1/SessionService/Sessions/{SessionId}        (auth required)
+ *   DELETE /redfish/v1/SessionService/Sessions/{SessionId}        (auth required)
+ *
+ * Authentication:
+ *   - Protected endpoints accept Basic Auth OR X-Auth-Token header.
+ *   - POST /redfish/v1/SessionService/Sessions requires NO prior auth (it IS the login).
+ */
+
+import { httpCodes } from '../../fixtures/api/httpCodes'
+import { sessionFixtures } from '../../fixtures/api/redfish/session'
+
+const redfishUrl = (): string => Cypress.env('REDFISH_BASEURL') ?? 'http://localhost:8181'
+
+const basicAuthHeaders = (): Record<string, string> => {
+  const username = (Cypress.env('REDFISH_USERNAME') as string) ?? 'standalone'
+  const password = (Cypress.env('REDFISH_PASSWORD') as string) ?? 'G@ppm0ym'
+  return { Authorization: `Basic ${btoa(`${username}:${password}`)}` }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET/PATCH/PUT /redfish/v1/SessionService
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish SessionService - GET/PATCH/PUT /redfish/v1/SessionService', () => {
+  context(
+    'TC_SESSIONSERVICE_GET_RESOURCE - GET returns SessionService document with @odata.type and Sessions link',
+    () => {
+      it('returns SessionService resource with @odata.type and Sessions link using Basic Auth', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/SessionService`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body).to.have.property('@odata.context')
+          expect(response.body['@odata.type']).to.include('SessionService')
+          expect(response.body).to.have.property('Id', sessionFixtures.sessionService.success.response.Id)
+          expect(response.body).to.have.property('Name', sessionFixtures.sessionService.success.response.Name)
+          expect(response.body).to.have.property('Sessions')
+          expect(response.body.Sessions).to.have.property('@odata.id', '/redfish/v1/SessionService/Sessions')
+        })
+      })
+
+      it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/SessionService`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+        })
+      })
+    }
+  )
+
+  context('TC_SESSIONSERVICE_PATCH_RESOURCE - PATCH updates and returns current SessionService state', () => {
+    it('returns updated SessionService resource body using Basic Auth', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `${redfishUrl()}/redfish/v1/SessionService`,
+        headers: basicAuthHeaders(),
+        body: { SessionTimeout: 1800 },
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.body['@odata.type']).to.include('SessionService')
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `${redfishUrl()}/redfish/v1/SessionService`,
+        body: {},
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+  })
+
+  context('TC_SESSIONSERVICE_PUT_RESOURCE - PUT returns current SessionService state', () => {
+    it('returns current SessionService resource body with an empty request body using Basic Auth', () => {
+      cy.request({
+        method: 'PUT',
+        url: `${redfishUrl()}/redfish/v1/SessionService`,
+        headers: basicAuthHeaders(),
+        body: {},
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.body['@odata.type']).to.include('SessionService')
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+      cy.request({
+        method: 'PUT',
+        url: `${redfishUrl()}/redfish/v1/SessionService`,
+        body: {},
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET/POST /redfish/v1/SessionService/Sessions
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Sessions Collection - GET/POST /redfish/v1/SessionService/Sessions', () => {
+  before(() => {
+    // Delete any sessions left over from previous test runs so POST tests start clean
+    cy.request({
+      method: 'GET',
+      url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+      headers: basicAuthHeaders(),
+      failOnStatusCode: false
+    }).then((response) => {
+      if (response.status === httpCodes.SUCCESS) {
+        const members = response.body.Members as { '@odata.id': string }[]
+        members.forEach((m) => {
+          cy.request({
+            method: 'DELETE',
+            url: `${redfishUrl()}${m['@odata.id']}`,
+            headers: basicAuthHeaders(),
+            failOnStatusCode: false
+          })
+        })
+      }
+    })
+  })
+
+  context('TC_SESSIONS_POST_LOGIN - POST creates a session without prior authentication required', () => {
+    it('returns HTTP 201 with X-Auth-Token and Location header when using valid credentials', () => {
+      cy.request({
+        method: 'POST',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        body: sessionFixtures.validCredentials.request,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.CREATED)
+        expect(response.headers).to.have.property('x-auth-token')
+        expect(response.headers['x-auth-token']).to.be.a('string').and.not.equal('')
+        expect(response.headers).to.have.property('location')
+        expect(response.headers.location).to.include('/redfish/v1/SessionService/Sessions/')
+        // Cleanup: delete the session so subsequent tests start with no active session
+        const token = response.headers['x-auth-token'] as string
+        const sid = (response.body as { Id: string }).Id
+        cy.request({
+          method: 'DELETE',
+          url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/${sid}`,
+          headers: { 'X-Auth-Token': token },
+          failOnStatusCode: false
+        })
+      })
+    })
+
+    it('returns Session resource with @odata.type, Id, and UserName on successful login', () => {
+      cy.request({
+        method: 'POST',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        body: sessionFixtures.validCredentials.request,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.CREATED)
+        expect(response.body['@odata.type']).to.include('Session')
+        expect(response.body).to.have.property('Id')
+        expect(response.body).to.have.property('UserName', sessionFixtures.validCredentials.request.UserName)
+        // Cleanup: delete the session so subsequent tests start with no active session
+        const token = response.headers['x-auth-token'] as string
+        const sid = (response.body as { Id: string }).Id
+        cy.request({
+          method: 'DELETE',
+          url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/${sid}`,
+          headers: { 'X-Auth-Token': token },
+          failOnStatusCode: false
+        })
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized for incorrect username and password', () => {
+      cy.request({
+        method: 'POST',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        body: sessionFixtures.invalidCredentials.request,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+
+    it('returns HTTP 400 or 401 when UserName and Password fields are missing from request body', () => {
+      cy.request({
+        method: 'POST',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        body: sessionFixtures.missingFields.request,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.be.oneOf([httpCodes.BAD_REQUEST, httpCodes.UNAUTHORIZED])
+      })
+    })
+  })
+
+  context('TC_SESSIONS_GET_COLLECTION - GET returns SessionCollection with members array and count', () => {
+    it('returns SessionCollection resource with @odata.type, Members array, and count using Basic Auth', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        headers: basicAuthHeaders(),
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.body['@odata.type']).to.include('SessionCollection')
+        expect(response.body).to.have.property('Name', sessionFixtures.sessionCollection.success.response.Name)
+        expect(response.body).to.have.property('Members')
+        expect(response.body.Members).to.be.an('array')
+        expect(response.body).to.have.property('Members@odata.count')
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET/DELETE /redfish/v1/SessionService/Sessions/{SessionId}
+// Uses session created via POST; token stored in before() hook.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Individual Session - GET/DELETE /redfish/v1/SessionService/Sessions/{SessionId}', () => {
+  let authToken: string
+  let sessionId: string
+
+  before(() => {
+    cy.request({
+      method: 'POST',
+      url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+      body: sessionFixtures.validCredentials.request,
+      failOnStatusCode: false
+    }).then((response) => {
+      if (response.status === httpCodes.CREATED) {
+        authToken = response.headers['x-auth-token'] as string
+        sessionId = response.body.Id as string
+      }
+    })
+  })
+
+  context('TC_SESSION_GET_BY_ID - GET returns individual Session resource using X-Auth-Token or Basic Auth', () => {
+    it('returns Session resource with Id and UserName using X-Auth-Token header', () => {
+      if (!authToken || !sessionId) {
+        cy.log('Skipping: login failed in before()')
+        return
+      }
+
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/${sessionId}`,
+        headers: { 'X-Auth-Token': authToken },
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.body).to.have.property('Id', sessionId)
+        expect(response.body['@odata.type']).to.include('Session')
+        expect(response.body).to.have.property('UserName', sessionFixtures.validCredentials.request.UserName)
+      })
+    })
+
+    it('returns HTTP 404 for a session ID that does not exist in the system', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/00000000-does-not-exist`,
+        headers: basicAuthHeaders(),
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(404)
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/someid`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+  })
+
+  context('TC_SESSION_DELETE_BY_ID - DELETE removes active session (logout) and returns 204', () => {
+    it('returns HTTP 204 and removes the active session when using X-Auth-Token header (logout)', () => {
+      if (!authToken || !sessionId) {
+        cy.log('Skipping: login failed in before()')
+        return
+      }
+
+      cy.request({
+        method: 'DELETE',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/${sessionId}`,
+        headers: { 'X-Auth-Token': authToken },
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.NO_CONTENT)
+      })
+    })
+
+    it('returns HTTP 404 when attempting to delete a session ID that does not exist', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/00000000-does-not-exist`,
+        headers: basicAuthHeaders(),
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(404)
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/someid`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Token and session lifecycle edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Session - Token Lifecycle Edge Cases', () => {
+  context('TC_SESSION_TOKEN_VALIDATION - invalid and deleted session tokens are rejected with 401', () => {
+    it('returns HTTP 401 with error body when X-Auth-Token is an invalid or garbage value', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        headers: { 'X-Auth-Token': 'invalid-token-that-does-not-exist-12345' },
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+        expect(response.body).to.have.property('error')
+      })
+    })
+
+    it('returns HTTP 401 or 404 when using a token from an already-deleted session', () => {
+      let deletedToken: string
+      let deletedSessionId: string
+
+      // Create a session
+      cy.request({
+        method: 'POST',
+        url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+        body: sessionFixtures.validCredentials.request,
+        failOnStatusCode: false
+      }).then((response) => {
+        if (response.status === httpCodes.CREATED) {
+          deletedToken = response.headers['x-auth-token'] as string
+          deletedSessionId = response.body.Id as string
+
+          // Delete the session
+          cy.request({
+            method: 'DELETE',
+            url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/${deletedSessionId}`,
+            headers: { 'X-Auth-Token': deletedToken },
+            failOnStatusCode: false
+          }).then((delResponse) => {
+            expect(delResponse.status).to.eq(httpCodes.NO_CONTENT)
+
+            // Now use the deleted token — should be 401 or 404
+            cy.request({
+              method: 'GET',
+              url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/${deletedSessionId}`,
+              headers: { 'X-Auth-Token': deletedToken },
+              failOnStatusCode: false
+            }).then((getResponse) => {
+              expect(getResponse.status).to.be.oneOf([httpCodes.UNAUTHORIZED, 404])
+              expect(getResponse.body).to.have.property('error')
+            })
+          })
+        }
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SessionService resource — additional property checks
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish SessionService - Additional Properties', () => {
+  context(
+    'TC_SESSIONSERVICE_ADDITIONAL_PROPERTIES - ServiceEnabled state, member count and method restrictions',
+    () => {
+      it('GET SessionService resource returns ServiceEnabled set to true', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/SessionService`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body).to.have.property('ServiceEnabled', true)
+        })
+      })
+
+      it('Sessions collection returns Members@odata.count as a non-negative integer', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.SUCCESS)
+          expect(response.body['Members@odata.count']).to.be.a('number')
+          expect(response.body['Members@odata.count']).to.be.at.least(0)
+          if ((response.body['Members@odata.count'] as number) > 0) {
+            const members = response.body.Members as { '@odata.id': string }[]
+            expect(members[0]).to.have.property('@odata.id')
+            expect(members[0]['@odata.id']).to.include('/redfish/v1/SessionService/Sessions/')
+          }
+        })
+      })
+
+      it('returns HTTP 405 Method Not Allowed for POST on /redfish/v1/SessionService', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/SessionService`,
+          headers: basicAuthHeaders(),
+          body: {},
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(405)
+          expect(response.body).to.have.property('error')
+        })
+      })
+
+      it('POST Sessions response includes OData-Version: 4.0 header on successful login', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/SessionService/Sessions`,
+          body: sessionFixtures.validCredentials.request,
+          failOnStatusCode: false
+        }).then((loginResponse) => {
+          expect(loginResponse.status).to.eq(httpCodes.CREATED)
+          expect(loginResponse.headers['odata-version']).to.eq('4.0')
+
+          // Cleanup: delete the session we just created
+          const token = loginResponse.headers['x-auth-token'] as string
+          const sid = loginResponse.body.Id as string
+          cy.request({
+            method: 'DELETE',
+            url: `${redfishUrl()}/redfish/v1/SessionService/Sessions/${sid}`,
+            headers: { 'X-Auth-Token': token },
+            failOnStatusCode: false
+          })
+        })
+      })
+    }
+  )
+})

--- a/cypress/e2e/integration-redfish/systems/functional.spec.ts
+++ b/cypress/e2e/integration-redfish/systems/functional.spec.ts
@@ -26,9 +26,10 @@
 
 import { httpCodes } from '../../fixtures/api/httpCodes'
 import { systemsFixtures } from '../../fixtures/api/redfish/systems'
-import { basicAuthHeaders, createSystemIdResolver, redfishUrl } from '../helpers/redfish'
+import { basicAuthHeaders, createSystemIdResolver, isIsolatedRun, redfishUrl } from '../helpers/redfish'
 
 const systemId = createSystemIdResolver(systemsFixtures.testSystemId)
+const isolatedRun = isIsolatedRun()
 
 /**
  * Wrapper around cy.request() that logs each API call and its response to:
@@ -71,7 +72,8 @@ const loggedRequest = (
 //   7. Poll GET every 10 s, up to 3 min,  until PowerState = "On"
 //
 // Worst-case: 2 min pre-flight + ~7 min 10 s → test timeout set to 12 min.
-// Skips gracefully when device is unreachable (404/500).
+// In isolated mode the test skips gracefully when the device is unreachable.
+// In non-isolated mode those same responses fail the test immediately.
 // ─────────────────────────────────────────────────────────────────────────────
 describe('Functional Test - Redfish System Power Cycle - POST /redfish/v1/Systems/{ComputerSystemId}/Actions/ComputerSystem.Reset', () => {
   context(
@@ -106,7 +108,15 @@ describe('Functional Test - Redfish System Power Cycle - POST /redfish/v1/System
           // During boot the device may return 5xx (WSMAN unreachable) — treat as
           // transient and keep polling rather than failing the test immediately.
           if (response.status !== httpCodes.SUCCESS) {
-            cy.task('log', `    ⏳ Transient HTTP ${response.status} — device still booting, retrying …`)
+            const transientServerError = response.status >= 500
+
+            if (!isolatedRun && !transientServerError) {
+              throw new Error(
+                `Non-isolated run expected HTTP 200 while polling for PowerState="${targetState}", received HTTP ${response.status}`
+              )
+            }
+
+            cy.task('log', `    ⏳ HTTP ${response.status} while waiting for boot state — retrying …`)
             if (Date.now() >= deadline) {
               throw new Error(
                 `Timed out waiting for PowerState="${targetState}". Last poll returned HTTP ${response.status}`
@@ -134,6 +144,7 @@ describe('Functional Test - Redfish System Power Cycle - POST /redfish/v1/System
         this.timeout(12 * 60 * 1000)
         cy.task('log', '\n════════════════════════════════════════════════════════')
         cy.task('log', ' TEST: Redfish System Power Action Functional Test')
+        cy.task('log', ` MODE: ${isolatedRun ? 'isolated' : 'non-isolated'} (ISOLATE=${isolatedRun ? 'Y' : 'N'})`)
         cy.task('log', '════════════════════════════════════════════════════════')
 
         // ── Pre-flight: ensure device is reachable and PowerState = "On" ────────
@@ -156,6 +167,12 @@ describe('Functional Test - Redfish System Power Cycle - POST /redfish/v1/System
                 `  ⏳ Pre-flight HTTP ${preflight.status} — device recovering, retrying in ${POLL_INTERVAL_MS / 1000}s …`
               )
               if (Date.now() >= deadline) {
+                if (!isolatedRun) {
+                  throw new Error(
+                    `Non-isolated run requires pre-flight GET to recover to HTTP 200, last status was ${preflight.status}`
+                  )
+                }
+
                 cy.task('log', `  ⚠️  Pre-flight deadline exceeded after repeated ${preflight.status} — skipping test`)
                 this.skip()
                 return
@@ -166,6 +183,12 @@ describe('Functional Test - Redfish System Power Cycle - POST /redfish/v1/System
             }
 
             if (preflight.status !== httpCodes.SUCCESS) {
+              if (!isolatedRun) {
+                throw new Error(
+                  `Non-isolated run requires a reachable system, received HTTP ${preflight.status} for /Systems/${systemId()}`
+                )
+              }
+
               cy.task('log', `  ⚠️  Device unavailable (HTTP ${preflight.status}) — skipping test`)
               this.skip()
               return
@@ -183,6 +206,12 @@ describe('Functional Test - Redfish System Power Cycle - POST /redfish/v1/System
                 body: { ResetType: 'On' },
                 failOnStatusCode: false
               }).then((powerOnResp) => {
+                if (!isolatedRun && powerOnResp.status !== 202) {
+                  throw new Error(
+                    `Non-isolated run expected ResetType=On to return HTTP 202, received HTTP ${powerOnResp.status}`
+                  )
+                }
+
                 if (powerOnResp.status === 202) {
                   cy.task('log', `  ✅ Power-on command accepted (202) — waiting for PowerState="On" …`)
                 } else {

--- a/cypress/e2e/integration-redfish/systems/functional.spec.ts
+++ b/cypress/e2e/integration-redfish/systems/functional.spec.ts
@@ -1,0 +1,259 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Redfish Computer System — Functional Tests
+ *
+ * Exercises end-to-end functional correctness of Computer System actions via
+ * the Redfish API, verifying that actions produce real-world state changes on
+ * a live AMT device.
+ *
+ * Every API call is logged in real-time to:
+ *   • The Cypress runner (cy.log)
+ *   • The terminal stdout (via cy.task)
+ *   • A timestamped file under cypress/logs/  (via cy.task)
+ *
+ * Prerequisites:
+ *   • REDFISH_SYSTEM_ID env var must point to a reachable, powered-ON device.
+ *   • Console backend running on REDFISH_BASEURL (default: https://localhost:8181).
+ *
+ * Run with:
+ *   npx cypress run --config-file cypress.redfish.config.ts
+ *   npm run cy-runner:redfish
+ */
+
+import { httpCodes } from '../../fixtures/api/httpCodes'
+import { systemsFixtures } from '../../fixtures/api/redfish/systems'
+import { basicAuthHeaders, createSystemIdResolver, redfishUrl } from '../helpers/redfish'
+
+const systemId = createSystemIdResolver(systemsFixtures.testSystemId)
+
+/**
+ * Wrapper around cy.request() that logs each API call and its response to:
+ *   • cy.log()         — shown in the Cypress runner / interactive UI
+ *   • cy.task('log')   — written to stdout AND the timestamped log file
+ *
+ * @param label  Short label shown in log lines, e.g. "Step 2 ForceOff"
+ * @param options Standard cy.request options (failOnStatusCode defaults to false)
+ */
+const loggedRequest = (
+  label: string,
+  options: Partial<Cypress.RequestOptions> & { url: string }
+): Cypress.Chainable<Cypress.Response<unknown>> => {
+  const method = (options.method ?? 'GET') as string
+  const bodyStr = options.body != null ? `  body: ${JSON.stringify(options.body)}` : ''
+  const reqLine = `  [${label}] → ${method} ${options.url}${bodyStr}`
+  cy.task('log', reqLine)
+  cy.log(`→ **${method}** \`${options.url}\``)
+  return cy.request({ failOnStatusCode: false, ...options } as Cypress.RequestOptions).then((res) => {
+    const preview = JSON.stringify(res.body).slice(0, 600)
+    cy.task('log', `  [${label}] ← ${res.status}  ${preview}`)
+    cy.log(`← **${res.status}**`)
+    return cy.wrap(res)
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Power Cycle Lifecycle — Full Power OFF → ON flow with recursive state polling
+//
+// Flow:
+//   Pre-flight: Poll until PowerState = "On" (max 2 min) — handles re-runs
+//               where the device is still booting from a previous cycle.
+//   1. GET  system  → assert PowerState is "On"
+//   2. POST ForceOff → assert 202 Accepted
+//   3. Poll GET every 10 s, up to 60 s,   until PowerState = "Off"
+//          (ForceOff is a hard power cut — device loses power within seconds)
+//   4. Fixed 10-second settle wait
+//   5. POST On      → assert 202 Accepted
+//   6. Fixed 3-minute boot wait
+//   7. Poll GET every 10 s, up to 3 min,  until PowerState = "On"
+//
+// Worst-case: 2 min pre-flight + ~7 min 10 s → test timeout set to 12 min.
+// Skips gracefully when device is unreachable (404/500).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Functional Test - Redfish System Power Cycle - POST /redfish/v1/Systems/{ComputerSystemId}/Actions/ComputerSystem.Reset', () => {
+  context(
+    'TC_SYSTEM_POWER_CYCLE_FORCE_OFF_TO_ON - ForceOff then On transitions device through Off state and back to On',
+    () => {
+      /** Interval between each poll GET */
+      const POLL_INTERVAL_MS = 10_000
+      /**
+       * Max wait for PowerState to reach "Off" after a ForceOff (hard power cut).
+       * ForceOff is instantaneous at the hardware level — 60 s is generous.
+       */
+      const POWER_OFF_TIMEOUT_MS = 60_000
+      /**
+       * Max wait for PowerState to reach "On" after booting, and for the
+       * pre-flight poll. Boot involves full OS startup, so 3 min is appropriate.
+       */
+      const POWER_ON_TIMEOUT_MS = 3 * 60 * 1000
+
+      /**
+       * Recursively polls GET /redfish/v1/Systems/{id} until PowerState equals
+       * targetState. Logs every poll result to terminal and log file.
+       * Throws (fails the test) if deadline is exceeded.
+       */
+      const pollPowerState = (targetState: string, deadline: number = Date.now() + POWER_ON_TIMEOUT_MS): void => {
+        loggedRequest(`POLL→"${targetState}"`, {
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          timeout: 120000,
+          failOnStatusCode: false
+        }).then((response) => {
+          // During boot the device may return 5xx (WSMAN unreachable) — treat as
+          // transient and keep polling rather than failing the test immediately.
+          if (response.status !== httpCodes.SUCCESS) {
+            cy.task('log', `    ⏳ Transient HTTP ${response.status} — device still booting, retrying …`)
+            if (Date.now() >= deadline) {
+              throw new Error(
+                `Timed out waiting for PowerState="${targetState}". Last poll returned HTTP ${response.status}`
+              )
+            }
+            cy.wait(POLL_INTERVAL_MS)
+            pollPowerState(targetState, deadline)
+            return
+          }
+          const current = (response.body as Record<string, string>).PowerState
+          cy.task('log', `    PowerState: "${current}" (target: "${targetState}")`)
+          if (current === targetState) {
+            cy.task('log', `    ✅ PowerState reached: "${targetState}"`)
+            return
+          }
+          if (Date.now() >= deadline) {
+            throw new Error(`Timed out waiting for PowerState="${targetState}". Last observed: "${current}"`)
+          }
+          cy.wait(POLL_INTERVAL_MS)
+          pollPowerState(targetState, deadline)
+        })
+      }
+
+      it('performs ForceOff then On cycle and verifies PowerState transitions through Off to On', function () {
+        this.timeout(12 * 60 * 1000)
+        cy.task('log', '\n════════════════════════════════════════════════════════')
+        cy.task('log', ' TEST: Redfish System Power Action Functional Test')
+        cy.task('log', '════════════════════════════════════════════════════════')
+
+        // ── Pre-flight: ensure device is reachable and PowerState = "On" ────────
+        // Retries on transient 5xx (device recovering from a previous Reset barrage).
+        // Skips immediately only on 4xx (device not registered).
+        // If device is powered off, sends ResetType=On then polls until "On".
+        const attemptPreFlight = (deadline: number): void => {
+          cy.task('log', '\n── Pre-flight: check device reachability & PowerState ──')
+          loggedRequest('Pre-flight GET', {
+            method: 'GET',
+            url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+            headers: basicAuthHeaders(),
+            failOnStatusCode: false
+          }).then((preflight) => {
+            // Transient 5xx — device may be recovering from previous test's Reset commands.
+            // Retry until the deadline rather than skipping immediately.
+            if (preflight.status >= 500) {
+              cy.task(
+                'log',
+                `  ⏳ Pre-flight HTTP ${preflight.status} — device recovering, retrying in ${POLL_INTERVAL_MS / 1000}s …`
+              )
+              if (Date.now() >= deadline) {
+                cy.task('log', `  ⚠️  Pre-flight deadline exceeded after repeated ${preflight.status} — skipping test`)
+                this.skip()
+                return
+              }
+              cy.wait(POLL_INTERVAL_MS)
+              attemptPreFlight(deadline)
+              return
+            }
+
+            if (preflight.status !== httpCodes.SUCCESS) {
+              cy.task('log', `  ⚠️  Device unavailable (HTTP ${preflight.status}) — skipping test`)
+              this.skip()
+              return
+            }
+
+            const preState = (preflight.body as Record<string, string>).PowerState
+            cy.task('log', `  Current PowerState: "${preState}"`)
+
+            if (preState !== 'On') {
+              cy.task('log', `  Device is "${preState}" — sending ResetType=On to power it up …`)
+              loggedRequest('Pre-flight PowerOn', {
+                method: 'POST',
+                url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+                headers: basicAuthHeaders(),
+                body: { ResetType: 'On' },
+                failOnStatusCode: false
+              }).then((powerOnResp) => {
+                if (powerOnResp.status === 202) {
+                  cy.task('log', `  ✅ Power-on command accepted (202) — waiting for PowerState="On" …`)
+                } else {
+                  cy.task('log', `  ⚠️  Power-on command returned HTTP ${powerOnResp.status} — will still poll …`)
+                }
+                pollPowerState('On', Date.now() + POWER_ON_TIMEOUT_MS)
+              })
+            }
+
+            // ── Step 1: Confirm PowerState is "On" ──────────────────────────────
+            cy.task('log', '\n── Step 1: Confirm PowerState is "On" ──────────────────')
+            loggedRequest('Step 1 GET', {
+              method: 'GET',
+              url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+              headers: basicAuthHeaders()
+            }).then((step1) => {
+              expect(step1.body, 'Step 1: PowerState must be "On"').to.have.property('PowerState', 'On')
+              cy.task('log', '  ✅ PowerState confirmed: "On"')
+
+              // ── Step 2: POST ForceOff ──────────────────────────────────────────
+              cy.task('log', '\n── Step 2: POST ForceOff ────────────────────────────────')
+              loggedRequest('Step 2 ForceOff', {
+                method: 'POST',
+                url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+                headers: basicAuthHeaders(),
+                body: systemsFixtures.reset.forceOff
+              }).then((step2) => {
+                expect(step2.status, 'Step 2: ForceOff must return 202').to.eq(202)
+                cy.task('log', '  ✅ ForceOff accepted (202)')
+
+                // ── Step 3: Poll until PowerState = "Off" (max 60 s) ───────────
+                // ForceOff is a hard power cut — the device loses power within seconds.
+                cy.task('log', '\n── Step 3: Poll for PowerState="Off" (max 60 s) ─────────')
+                pollPowerState('Off', Date.now() + POWER_OFF_TIMEOUT_MS)
+
+                // ── Step 4: 10-second settle wait ─────────────────────────────
+                cy.task('log', '\n── Step 4: 10-second settle wait ────────────────────────')
+                cy.wait(10_000)
+                cy.task('log', '  ✅ Settle wait complete')
+
+                // ── Step 5: POST On ────────────────────────────────────────────
+                cy.task('log', '\n── Step 5: POST On ──────────────────────────────────────')
+                loggedRequest('Step 5 On', {
+                  method: 'POST',
+                  url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+                  headers: basicAuthHeaders(),
+                  body: systemsFixtures.reset.on
+                }).then((step5) => {
+                  expect(step5.status, 'Step 5: Power On must return 202').to.eq(202)
+                  cy.task('log', '  ✅ Power On accepted (202)')
+
+                  // ── Step 6: Fixed 3-minute boot wait ────────────────────────
+                  cy.task('log', '\n── Step 6: Fixed 3-minute boot wait ─────────────────────')
+                  cy.wait(3 * 60 * 1000)
+                  cy.task('log', '  ✅ Boot wait complete')
+
+                  // ── Step 7: Poll until PowerState = "On" (max 3 min) ────────
+                  cy.task('log', '\n── Step 7: Poll for PowerState="On" (max 3 min) ────────')
+                  pollPowerState('On')
+
+                  cy.task('log', '\n════════════════════════════════════════════════════════')
+                  cy.task('log', ' ✅ TEST PASSED: Power cycle complete')
+                  cy.task('log', '════════════════════════════════════════════════════════')
+                })
+              })
+            })
+          })
+        }
+
+        attemptPreFlight(Date.now() + 2 * 60 * 1000)
+      })
+    }
+  )
+})

--- a/cypress/e2e/integration-redfish/systems/systems.spec.ts
+++ b/cypress/e2e/integration-redfish/systems/systems.spec.ts
@@ -14,15 +14,30 @@
  *
  * The {ComputerSystemId} parameter must be a valid UUID/GUID.
  * Tests that target a specific device use the REDFISH_SYSTEM_ID env variable.
- * When a real device is not available, device-specific tests gracefully accept
- * 404 (system not found) alongside success responses.
+ * When ISOLATE=Y, device-specific positive tests may tolerate device-unavailable
+ * statuses (for isolated/off-device runs). When ISOLATE=N, those same tests
+ * require strict on-device success and reject 404/internal error responses.
  */
 
 import { httpCodes } from '../../fixtures/api/httpCodes'
 import { systemsFixtures } from '../../fixtures/api/redfish/systems'
-import { basicAuthHeaders, createSystemIdResolver, redfishUrl } from '../helpers/redfish'
+import { basicAuthHeaders, createSystemIdResolver, deviceAllowedStatuses, redfishUrl } from '../helpers/redfish'
 
 const systemId = createSystemIdResolver(systemsFixtures.testSystemId)
+
+const expectAllowedDeviceStatus = (
+  actualStatus: number,
+  successStatuses: number | number[],
+  statusesAllowedInAllModes: number[] = []
+): void => {
+  const normalizedSuccessStatuses = Array.isArray(successStatuses) ? successStatuses : [successStatuses]
+  const allowedStatuses = deviceAllowedStatuses(
+    [...normalizedSuccessStatuses, ...statusesAllowedInAllModes],
+    [404, httpCodes.INTERNAL_SERVER_ERROR]
+  )
+
+  expect(actualStatus).to.be.oneOf(allowedStatuses)
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // GET /redfish/v1/Systems
@@ -94,11 +109,7 @@ describe('Redfish Computer System - GET /redfish/v1/Systems/{ComputerSystemId}',
         headers: basicAuthHeaders(),
         failOnStatusCode: false
       }).then((response) => {
-        expect(response.status).to.be.oneOf([
-          httpCodes.SUCCESS,
-          404,
-          httpCodes.INTERNAL_SERVER_ERROR
-        ])
+        expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
         if (response.status === httpCodes.SUCCESS) {
           expect(response.body['@odata.type']).to.include('ComputerSystem')
           expect(response.body).to.have.property('Id', systemId())
@@ -146,11 +157,7 @@ describe('Redfish Computer System - PATCH /redfish/v1/Systems/{ComputerSystemId}
           body: systemsFixtures.patchBootSettings.request,
           failOnStatusCode: false
         }).then((response) => {
-          expect(response.status).to.be.oneOf([
-            httpCodes.SUCCESS,
-            404,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             expect(response.body['@odata.type']).to.include('ComputerSystem')
           }
@@ -185,6 +192,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             expect(response.body).to.have.property('PowerState')
             if (response.body.PowerState) {
@@ -201,6 +209,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             expect(response.body).to.have.property('SystemType')
             if (response.body.SystemType) {
@@ -217,6 +226,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS && response.body.Status) {
             const { Status } = response.body as { Status: Record<string, string> }
             expect(Status).to.be.an('object')
@@ -240,6 +250,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             expect(response.body).to.have.property('BiosVersion')
             if (response.body.BiosVersion != null) {
@@ -256,6 +267,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             if (response.body.Manufacturer != null) {
               expect(response.body.Manufacturer).to.be.a('string')
@@ -277,6 +289,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             expect(response.body).to.have.property('Actions')
             expect(response.body.Actions).to.have.property('#ComputerSystem.Reset')
@@ -295,6 +308,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           failOnStatusCode: false,
           timeout: 45000
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS && response.body.MemorySummary) {
             const mem = response.body.MemorySummary as Record<string, unknown>
             expect(mem).to.be.an('object')
@@ -317,6 +331,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           failOnStatusCode: false,
           timeout: 45000
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS && response.body.ProcessorSummary) {
             const proc = response.body.ProcessorSummary as Record<string, unknown>
             expect(proc).to.be.an('object')
@@ -338,6 +353,7 @@ describe('Redfish Computer System - Detailed Properties', () => {
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             expect(response.body['@odata.context']).to.equal('/redfish/v1/$metadata#ComputerSystem.ComputerSystem')
             expect(response.body['@odata.id']).to.equal(`/redfish/v1/Systems/${systemId()}`)
@@ -427,11 +443,7 @@ describe('Redfish Computer System - PATCH Additional Scenarios', () => {
           failOnStatusCode: false,
           timeout: 45000
         }).then((response) => {
-          expect(response.status).to.be.oneOf([
-            httpCodes.SUCCESS,
-            404,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             expect(response.body['@odata.type']).to.include('ComputerSystem')
           }
@@ -446,11 +458,7 @@ describe('Redfish Computer System - PATCH Additional Scenarios', () => {
           body: systemsFixtures.patchBootSettings.invalidTarget,
           failOnStatusCode: false
         }).then((response) => {
-          expect(response.status).to.be.oneOf([
-            httpCodes.BAD_REQUEST,
-            404,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, httpCodes.BAD_REQUEST)
           if (response.status === httpCodes.BAD_REQUEST) {
             expect(response.body).to.have.property('error')
           }
@@ -465,11 +473,7 @@ describe('Redfish Computer System - PATCH Additional Scenarios', () => {
           body: systemsFixtures.patchBootSettings.invalidEnabled,
           failOnStatusCode: false
         }).then((response) => {
-          expect(response.status).to.be.oneOf([
-            httpCodes.BAD_REQUEST,
-            404,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, httpCodes.BAD_REQUEST)
           if (response.status === httpCodes.BAD_REQUEST) {
             expect(response.body).to.have.property('error')
           }
@@ -498,12 +502,7 @@ describe('Redfish Computer System - PATCH Additional Scenarios', () => {
           failOnStatusCode: false,
           timeout: 45000
         }).then((response) => {
-          expect(response.status).to.be.oneOf([
-            httpCodes.SUCCESS,
-            httpCodes.BAD_REQUEST,
-            404,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, [httpCodes.SUCCESS, httpCodes.BAD_REQUEST])
         })
       })
 
@@ -516,11 +515,7 @@ describe('Redfish Computer System - PATCH Additional Scenarios', () => {
           body: '{"Boot": {"BootSourceOverrideEnabled": "Once"',
           failOnStatusCode: false
         }).then((response) => {
-          expect(response.status).to.be.oneOf([
-            httpCodes.BAD_REQUEST,
-            404,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, httpCodes.BAD_REQUEST)
           if (response.status === httpCodes.BAD_REQUEST) {
             expect(response.body).to.have.property('error')
           }
@@ -544,6 +539,7 @@ describe('Redfish Computer System - Optional Properties and Method Edge Cases', 
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
+          expectAllowedDeviceStatus(response.status, httpCodes.SUCCESS)
           if (response.status === httpCodes.SUCCESS) {
             if (response.body.Description != null) {
               expect(response.body.Description).to.be.a('string')
@@ -562,7 +558,7 @@ describe('Redfish Computer System - Optional Properties and Method Edge Cases', 
           headers: basicAuthHeaders(),
           failOnStatusCode: false
         }).then((response) => {
-          expect(response.status).to.be.oneOf([httpCodes.SUCCESS, 405])
+          expectAllowedDeviceStatus(response.status, [httpCodes.SUCCESS, 405])
           if (response.status === httpCodes.SUCCESS) {
             expect(response.headers['odata-version']).to.eq('4.0')
             expect(response.headers['content-type']).to.include('application/json')
@@ -660,11 +656,7 @@ describe('Redfish System Reset Action - POST /redfish/v1/Systems/{ComputerSystem
           body: systemsFixtures.reset.missingResetType,
           failOnStatusCode: false
         }).then((response) => {
-          expect(response.status).to.be.oneOf([
-            httpCodes.BAD_REQUEST,
-            404,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, httpCodes.BAD_REQUEST)
         })
       })
 
@@ -678,12 +670,7 @@ describe('Redfish System Reset Action - POST /redfish/v1/Systems/{ComputerSystem
         }).then((response) => {
           // 202 Accepted (success), 404 (device not found/registered),
           // or 409 Conflict (device busy — previous reset still in progress)
-          expect(response.status).to.be.oneOf([
-            202,
-            404,
-            409,
-            httpCodes.INTERNAL_SERVER_ERROR
-          ])
+          expectAllowedDeviceStatus(response.status, 202, [409])
           if (response.status === 202) {
             expect(response.body).to.have.property('@odata.type')
             expect(response.body['@odata.type']).to.include('Task')
@@ -751,12 +738,7 @@ describe('Redfish System Reset Action - All ResetTypes', () => {
             failOnStatusCode: false,
             timeout: 45000
           }).then((response) => {
-            expect(response.status).to.be.oneOf([
-              202,
-              404,
-              409,
-              httpCodes.INTERNAL_SERVER_ERROR
-            ])
+            expectAllowedDeviceStatus(response.status, 202, [409])
             if (response.status === 202) {
               expect(response.body['@odata.type']).to.include('Task')
               expect(response.body).to.have.property('TaskState', 'Completed')
@@ -785,11 +767,7 @@ describe('Redfish System Reset Action - Malformed JSON', () => {
         body: '{"ResetType": "On"',
         failOnStatusCode: false
       }).then((response) => {
-        expect(response.status).to.be.oneOf([
-          httpCodes.BAD_REQUEST,
-          404,
-          httpCodes.INTERNAL_SERVER_ERROR
-        ])
+        expectAllowedDeviceStatus(response.status, httpCodes.BAD_REQUEST)
         if (response.status === httpCodes.BAD_REQUEST) {
           expect(response.body).to.have.property('error')
         }
@@ -867,6 +845,7 @@ describe('Redfish Complete BIOS Reset Flow', () => {
           body: systemsFixtures.patchBootSettings.biosSetup,
           failOnStatusCode: false
         }).then((patchResponse) => {
+          expectAllowedDeviceStatus(patchResponse.status, httpCodes.SUCCESS)
           // Only proceed to reset if PATCH succeeded
           if (patchResponse.status === httpCodes.SUCCESS) {
             cy.request({
@@ -876,12 +855,7 @@ describe('Redfish Complete BIOS Reset Flow', () => {
               body: systemsFixtures.reset.forceRestart,
               failOnStatusCode: false
             }).then((resetResponse) => {
-              expect(resetResponse.status).to.be.oneOf([
-                202,
-                409,
-                404,
-                httpCodes.INTERNAL_SERVER_ERROR
-              ])
+              expectAllowedDeviceStatus(resetResponse.status, 202, [409])
               if (resetResponse.status === 202) {
                 expect(resetResponse.body['@odata.type']).to.include('Task')
                 expect(resetResponse.body).to.have.property('TaskState', 'Completed')

--- a/cypress/e2e/integration-redfish/systems/systems.spec.ts
+++ b/cypress/e2e/integration-redfish/systems/systems.spec.ts
@@ -1,0 +1,900 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+/**
+ * Redfish Computer Systems API Tests
+ *
+ * Endpoints covered:
+ *   GET   /redfish/v1/Systems                                               (auth required)
+ *   GET   /redfish/v1/Systems/{ComputerSystemId}                            (auth required)
+ *   PATCH /redfish/v1/Systems/{ComputerSystemId}                            (auth required)
+ *   POST  /redfish/v1/Systems/{ComputerSystemId}/Actions/ComputerSystem.Reset (auth required)
+ *
+ * The {ComputerSystemId} parameter must be a valid UUID/GUID.
+ * Tests that target a specific device use the REDFISH_SYSTEM_ID env variable.
+ * When a real device is not available, device-specific tests gracefully accept
+ * 404 (system not found) alongside success responses.
+ */
+
+import { httpCodes } from '../../fixtures/api/httpCodes'
+import { systemsFixtures } from '../../fixtures/api/redfish/systems'
+import { basicAuthHeaders, createSystemIdResolver, redfishUrl } from '../helpers/redfish'
+
+const systemId = createSystemIdResolver(systemsFixtures.testSystemId)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/Systems
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Systems Collection - GET /redfish/v1/Systems', () => {
+  context('TC_SYSTEMS_GET_COLLECTION - authenticated GET returns ComputerSystemCollection with OData headers', () => {
+    it('returns ComputerSystemCollection with @odata.type, Members array, and OData headers using Basic Auth', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/Systems`,
+        headers: basicAuthHeaders(),
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.headers['content-type']).to.include('application/json')
+        expect(response.headers['odata-version']).to.eq('4.0')
+        expect(response.body['@odata.type']).to.include('ComputerSystemCollection')
+        expect(response.body).to.have.property('Name', systemsFixtures.collection.success.response.Name)
+        expect(response.body).to.have.property('Members')
+        expect(response.body.Members).to.be.an('array')
+        expect(response.body).to.have.property('Members@odata.count')
+      })
+    })
+
+    it('returns @odata.id with value /redfish/v1/Systems in the collection response', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/Systems`,
+        headers: basicAuthHeaders(),
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.SUCCESS)
+        expect(response.body).to.have.property('@odata.id', '/redfish/v1/Systems')
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/Systems`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/Systems/{ComputerSystemId}
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Computer System - GET /redfish/v1/Systems/{ComputerSystemId}', () => {
+  context('TC_SYSTEM_GET_BY_ID - valid UUID returns ComputerSystem or 404; non-UUID returns 400', () => {
+    it('returns HTTP 400 for a system ID that is not a valid UUID format', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/Systems/not-a-valid-uuid`,
+        headers: basicAuthHeaders(),
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.BAD_REQUEST)
+      })
+    })
+
+    it('returns ComputerSystem resource or HTTP 404 when system ID is a valid UUID', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+        headers: basicAuthHeaders(),
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.be.oneOf([
+          httpCodes.SUCCESS,
+          404,
+          httpCodes.INTERNAL_SERVER_ERROR
+        ])
+        if (response.status === httpCodes.SUCCESS) {
+          expect(response.body['@odata.type']).to.include('ComputerSystem')
+          expect(response.body).to.have.property('Id', systemId())
+          expect(response.body).to.have.property('@odata.id', `/redfish/v1/Systems/${systemId()}`)
+        }
+      })
+    })
+
+    it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /redfish/v1/Systems/{ComputerSystemId}
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Computer System - PATCH /redfish/v1/Systems/{ComputerSystemId}', () => {
+  context(
+    'TC_SYSTEM_PATCH_BOOT_SETTINGS - valid UUID updates boot settings or returns 404; non-UUID returns 400',
+    () => {
+      it('returns HTTP 400 when PATCH uses a non-UUID system ID', () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/not-a-valid-uuid`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.request,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.BAD_REQUEST)
+        })
+      })
+
+      it('returns updated ComputerSystem resource or HTTP 404 when patching Boot settings', () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.request,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            httpCodes.SUCCESS,
+            404,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body['@odata.type']).to.include('ComputerSystem')
+          }
+        })
+      })
+
+      it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          body: systemsFixtures.patchBootSettings.request,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/Systems/{id} — detailed property assertions (device-guarded)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Computer System - Detailed Properties', () => {
+  context(
+    'TC_SYSTEM_RESOURCE_FIELD_SCHEMA - ComputerSystem resource fields conform to Redfish DSP0268 schema values',
+    () => {
+      it('PowerState field value matches a valid Redfish PowerState enum', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body).to.have.property('PowerState')
+            if (response.body.PowerState) {
+              expect(systemsFixtures.validPowerStates).to.include(response.body.PowerState)
+            }
+          }
+        })
+      })
+
+      it('SystemType field value matches a valid Redfish SystemType enum', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body).to.have.property('SystemType')
+            if (response.body.SystemType) {
+              expect(systemsFixtures.validSystemTypes).to.include(response.body.SystemType)
+            }
+          }
+        })
+      })
+
+      it('Status object contains valid State and Health enum values conforming to DSP0268', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS && response.body.Status) {
+            const { Status } = response.body as { Status: Record<string, string> }
+            expect(Status).to.be.an('object')
+            if (Status.State) {
+              expect(systemsFixtures.validStatusStates).to.include(Status.State)
+            }
+            if (Status.Health) {
+              expect(systemsFixtures.validHealthValues).to.include(Status.Health)
+            }
+            if (Status.HealthRollup) {
+              expect(systemsFixtures.validHealthValues).to.include(Status.HealthRollup)
+            }
+          }
+        })
+      })
+
+      it('BiosVersion field is a string type when present in the resource', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body).to.have.property('BiosVersion')
+            if (response.body.BiosVersion != null) {
+              expect(response.body.BiosVersion).to.be.a('string')
+            }
+          }
+        })
+      })
+
+      it('Manufacturer, Model, and SerialNumber fields are string type when present', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS) {
+            if (response.body.Manufacturer != null) {
+              expect(response.body.Manufacturer).to.be.a('string')
+            }
+            if (response.body.Model != null) {
+              expect(response.body.Model).to.be.a('string')
+            }
+            if (response.body.SerialNumber != null) {
+              expect(response.body.SerialNumber).to.be.a('string')
+            }
+          }
+        })
+      })
+
+      it('Actions[#ComputerSystem.Reset] target URL matches the ComputerSystem Reset action path', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body).to.have.property('Actions')
+            expect(response.body.Actions).to.have.property('#ComputerSystem.Reset')
+            const resetAction = response.body.Actions['#ComputerSystem.Reset'] as { target: string }
+            expect(resetAction).to.have.property('target')
+            expect(resetAction.target).to.equal(`/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`)
+          }
+        })
+      })
+
+      it('MemorySummary contains TotalSystemMemoryGiB as a positive number when present', { retries: 2 }, () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false,
+          timeout: 45000
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS && response.body.MemorySummary) {
+            const mem = response.body.MemorySummary as Record<string, unknown>
+            expect(mem).to.be.an('object')
+            if (mem.TotalSystemMemoryGiB != null) {
+              expect(mem.TotalSystemMemoryGiB).to.be.a('number')
+              expect(mem.TotalSystemMemoryGiB as number).to.be.greaterThan(0)
+            }
+            if (mem.MemoryMirroring != null) {
+              expect(systemsFixtures.validMemoryMirroring).to.include(mem.MemoryMirroring as string)
+            }
+          }
+        })
+      })
+
+      it('ProcessorSummary contains Count as positive number and Model as string when present', { retries: 2 }, () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false,
+          timeout: 45000
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS && response.body.ProcessorSummary) {
+            const proc = response.body.ProcessorSummary as Record<string, unknown>
+            expect(proc).to.be.an('object')
+            if (proc.Count != null) {
+              expect(proc.Count).to.be.a('number')
+              expect(proc.Count as number).to.be.greaterThan(0)
+            }
+            if (proc.Model != null) {
+              expect(proc.Model).to.be.a('string')
+            }
+          }
+        })
+      })
+
+      it('returns exact @odata.context, @odata.id, and Id values matching the requested system', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body['@odata.context']).to.equal('/redfish/v1/$metadata#ComputerSystem.ComputerSystem')
+            expect(response.body['@odata.id']).to.equal(`/redfish/v1/Systems/${systemId()}`)
+            expect(response.body).to.have.property('Id', systemId())
+          }
+        })
+      })
+
+      it('returns HTTP 404 with error object for a valid UUID that has no matching system record', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemsFixtures.nonExistentSystemId}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+          expect(response.body).to.have.property('error')
+        })
+      })
+    }
+  )
+})
+// ─────────────────────────────────────────────────────────────────────────────
+// Method Not Allowed on /redfish/v1/Systems/{ComputerSystemId}
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Computer System - Method Not Allowed', () => {
+  context(
+    'TC_SYSTEM_METHOD_NOT_ALLOWED - POST PUT DELETE on /redfish/v1/Systems/{id} return 405 with Redfish error body',
+    () => {
+      it('returns HTTP 405 with OData-Version header and error body for POST on system resource', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: {},
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(405)
+          expect(response.headers['odata-version']).to.eq('4.0')
+          expect(response.body).to.have.property('error')
+        })
+      })
+
+      it('returns HTTP 405 with OData-Version header and error body for PUT on system resource', () => {
+        cy.request({
+          method: 'PUT',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: {},
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(405)
+          expect(response.headers['odata-version']).to.eq('4.0')
+          expect(response.body).to.have.property('error')
+        })
+      })
+
+      it('returns HTTP 405 with OData-Version header and error body for DELETE on system resource', () => {
+        cy.request({
+          method: 'DELETE',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(405)
+          expect(response.headers['odata-version']).to.eq('4.0')
+          expect(response.body).to.have.property('error')
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /redfish/v1/Systems/{ComputerSystemId} — additional validation cases
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Computer System - PATCH Additional Scenarios', () => {
+  context(
+    'TC_SYSTEM_PATCH_ADDITIONAL_SCENARIOS - BiosSetup target, invalid enums, empty body and malformed JSON each produce correct status',
+    () => {
+      it('returns HTTP 200 or 404 when patching BootSourceOverrideTarget to BiosSetup', { retries: 2 }, () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.biosSetup,
+          failOnStatusCode: false,
+          timeout: 45000
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            httpCodes.SUCCESS,
+            404,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body['@odata.type']).to.include('ComputerSystem')
+          }
+        })
+      })
+
+      it('returns HTTP 400 for an invalid BootSourceOverrideTarget enum value', () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.invalidTarget,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            httpCodes.BAD_REQUEST,
+            404,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+          if (response.status === httpCodes.BAD_REQUEST) {
+            expect(response.body).to.have.property('error')
+          }
+        })
+      })
+
+      it('returns HTTP 400 for an invalid BootSourceOverrideEnabled enum value', () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.invalidEnabled,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            httpCodes.BAD_REQUEST,
+            404,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+          if (response.status === httpCodes.BAD_REQUEST) {
+            expect(response.body).to.have.property('error')
+          }
+        })
+      })
+
+      it('returns HTTP 404 with error object when PATCH targets a UUID with no matching system', () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemsFixtures.nonExistentSystemId}`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.request,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(404)
+          expect(response.body).to.have.property('error')
+        })
+      })
+
+      it('returns HTTP 200, 400, or 404 for a PATCH with an empty JSON body', { retries: 2 }, () => {
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.empty,
+          failOnStatusCode: false,
+          timeout: 45000
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            httpCodes.SUCCESS,
+            httpCodes.BAD_REQUEST,
+            404,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+        })
+      })
+
+      it('returns HTTP 400 for a truncated or malformed JSON body in PATCH request', () => {
+        // Send raw truncated JSON to trigger parse error
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: { ...basicAuthHeaders(), 'Content-Type': 'application/json' },
+          body: '{"Boot": {"BootSourceOverrideEnabled": "Once"',
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            httpCodes.BAD_REQUEST,
+            404,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+          if (response.status === httpCodes.BAD_REQUEST) {
+            expect(response.body).to.have.property('error')
+          }
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /redfish/v1/Systems/{id} — optional properties + HEAD + edge IDs
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Computer System - Optional Properties and Method Edge Cases', () => {
+  context(
+    'TC_SYSTEM_OPTIONAL_FIELDS_AND_HEAD - optional string fields are typed correctly and HEAD returns headers-only response',
+    () => {
+      it('Description and HostName fields are string type when present in the resource', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          if (response.status === httpCodes.SUCCESS) {
+            if (response.body.Description != null) {
+              expect(response.body.Description).to.be.a('string')
+            }
+            if (response.body.HostName != null) {
+              expect(response.body.HostName).to.be.a('string')
+            }
+          }
+        })
+      })
+
+      it('returns HTTP 200 with empty body or HTTP 405 for HEAD on the system resource', () => {
+        cy.request({
+          method: 'HEAD',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([httpCodes.SUCCESS, 405])
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.headers['odata-version']).to.eq('4.0')
+            expect(response.headers['content-type']).to.include('application/json')
+            expect(response.body).to.satisfy(
+              (b: unknown) => b === '' || b === null || (typeof b === 'object' && Object.keys(b as object).length === 0)
+            )
+          }
+        })
+      })
+
+      it('returns HTTP 200 collection or HTTP 404 for GET with an empty system ID path segment', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems/`,
+          headers: basicAuthHeaders(),
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([httpCodes.SUCCESS, 404])
+          if (response.status === httpCodes.SUCCESS) {
+            expect(response.body).to.satisfy((b: Record<string, unknown>) => 'Members' in b || '@odata.type' in b)
+          }
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Security / Input Validation Edge Cases  (Postman #42–48)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Computer System - Security Edge Cases', () => {
+  context(
+    'TC_SYSTEM_INPUT_VALIDATION_SECURITY - XSS, SQL injection, path traversal and oversized IDs all return 400 or 404',
+    () => {
+      const badIds: { label: string; path: string }[] = [
+        { label: 'XSS attempt', path: "<script>alert('xss')</script>" },
+        { label: 'SQL injection', path: "' OR '1'='1" },
+        // Use percent-encoding so traversal markers are preserved in the route segment
+        // and not normalized by the client/router before request handling.
+        // { label: 'path traversal',        path: '../../../etc/passwd' },
+        { label: 'path traversal', path: '%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd' },
+        { label: 'null byte', path: 'system%00id' },
+        { label: 'unicode chars', path: encodeURIComponent('系统标识符') },
+        { label: 'long ID (51 chars)', path: 'a'.repeat(51) },
+        { label: 'very long ID (1024)', path: 'a'.repeat(1024) }
+      ]
+
+      badIds.forEach(({ label, path }) => {
+        it(`returns 400 or 404 for ${label} in system ID`, () => {
+          cy.request({
+            method: 'GET',
+            url: `${redfishUrl()}/redfish/v1/Systems/${path}`,
+            headers: basicAuthHeaders(),
+            failOnStatusCode: false
+          }).then((response) => {
+            expect(response.status).to.be.oneOf([
+              httpCodes.BAD_REQUEST,
+              404,
+              414
+            ])
+            if (response.headers['content-type']?.includes('application/json')) {
+              expect(response.body).to.have.property('error')
+            }
+          })
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /redfish/v1/Systems/{ComputerSystemId}/Actions/ComputerSystem.Reset
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish System Reset Action - POST /redfish/v1/Systems/{ComputerSystemId}/Actions/ComputerSystem.Reset', () => {
+  context(
+    'TC_SYSTEM_RESET_INPUT_VALIDATION - reset request validated and accepted or rejected based on input and device state',
+    () => {
+      it('returns HTTP 400 for a non-UUID system ID in Reset action URL', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/Systems/not-a-valid-uuid/Actions/ComputerSystem.Reset`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.reset.request,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.BAD_REQUEST)
+        })
+      })
+
+      it('returns HTTP 400 when ResetType field is absent from the Reset request body', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.reset.missingResetType,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([
+            httpCodes.BAD_REQUEST,
+            404,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+        })
+      })
+
+      it('returns HTTP 202 Accepted for a valid reset request, or 404/409 when device is unavailable', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.reset.request,
+          failOnStatusCode: false
+        }).then((response) => {
+          // 202 Accepted (success), 404 (device not found/registered),
+          // or 409 Conflict (device busy — previous reset still in progress)
+          expect(response.status).to.be.oneOf([
+            202,
+            404,
+            409,
+            httpCodes.INTERNAL_SERVER_ERROR
+          ])
+          if (response.status === 202) {
+            expect(response.body).to.have.property('@odata.type')
+            expect(response.body['@odata.type']).to.include('Task')
+            expect(response.body).to.have.property('TaskState', 'Completed')
+            expect(response.body).to.have.property('TaskStatus', 'OK')
+            expect(response.headers).to.have.property('location')
+          }
+        })
+      })
+
+      it('returns HTTP 401 Unauthorized when request has no authentication headers', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+          body: systemsFixtures.reset.request,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+        })
+      })
+
+      it('returns HTTP 400 with Redfish error @Message.ExtendedInfo for an invalid ResetType value', () => {
+        cy.request({
+          method: 'POST',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.reset.invalidResetType,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.BAD_REQUEST)
+          expect(response.body).to.have.property('error')
+          expect(response.body.error).to.have.property('@Message.ExtendedInfo')
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST .../Actions/ComputerSystem.Reset — all supported ResetTypes
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish System Reset Action - All ResetTypes', () => {
+  context(
+    'TC_SYSTEM_RESET_ALL_RESET_TYPES - each supported ResetType returns 202 Accepted or device-unavailable code',
+    () => {
+      const cases = [
+        { label: 'On', body: () => systemsFixtures.reset.on },
+        { label: 'ForceOff', body: () => systemsFixtures.reset.forceOff },
+        { label: 'ForceRestart', body: () => systemsFixtures.reset.forceRestart },
+        { label: 'GracefulRestart', body: () => systemsFixtures.reset.gracefulRestart },
+        { label: 'PowerCycle', body: () => systemsFixtures.reset.powerCycle }
+      ]
+
+      cases.forEach(({ label, body }) => {
+        // Each Reset relays to the AMT device over WSMAN. When multiple Resets
+        // are sent in quick succession the device may take longer than the default
+        // 15 s responseTimeout to reply. timeout:45000 gives it enough headroom,
+        // and retries:2 absorbs transient ECONNRESET drops between resets.
+        it(`accepts ResetType=${label} — 202 on success, 404/409 when device unavailable`, { retries: 2 }, () => {
+          cy.request({
+            method: 'POST',
+            url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+            headers: basicAuthHeaders(),
+            body: body(),
+            failOnStatusCode: false,
+            timeout: 45000
+          }).then((response) => {
+            expect(response.status).to.be.oneOf([
+              202,
+              404,
+              409,
+              httpCodes.INTERNAL_SERVER_ERROR
+            ])
+            if (response.status === 202) {
+              expect(response.body['@odata.type']).to.include('Task')
+              expect(response.body).to.have.property('TaskState', 'Completed')
+              expect(response.body).to.have.property('TaskStatus', 'OK')
+              expect(response.headers).to.have.property('location')
+              expect(response.headers.location).to.include('/redfish/v1/TaskService/Tasks/')
+              expect(response.headers['odata-version']).to.eq('4.0')
+            }
+          })
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reset — malformed JSON body (Postman #67)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish System Reset Action - Malformed JSON', () => {
+  context('TC_SYSTEM_RESET_MALFORMED_JSON - truncated JSON body in Reset request returns 400 Bad Request', () => {
+    it('returns HTTP 400 for a truncated or malformed JSON body in Reset action request', () => {
+      cy.request({
+        method: 'POST',
+        url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+        headers: { ...basicAuthHeaders(), 'Content-Type': 'application/json' },
+        body: '{"ResetType": "On"',
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.be.oneOf([
+          httpCodes.BAD_REQUEST,
+          404,
+          httpCodes.INTERNAL_SERVER_ERROR
+        ])
+        if (response.status === httpCodes.BAD_REQUEST) {
+          expect(response.body).to.have.property('error')
+        }
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Authentication — error body structure (Postman #68)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Authentication - Error Body Structure', () => {
+  context(
+    'TC_AUTH_UNAUTHORIZED_ERROR_STRUCTURE - unauthenticated and invalid credential requests return 401 with Redfish error body',
+    () => {
+      it('returns HTTP 401 with @Message.ExtendedInfo array for unauthenticated request to /redfish/v1/Systems', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+          expect(response.headers['content-type']).to.include('application/json')
+          expect(response.headers['odata-version']).to.eq('4.0')
+          expect(response.body).to.have.property('error')
+          expect(response.body.error).to.have.property('@Message.ExtendedInfo')
+          expect(response.body.error['@Message.ExtendedInfo']).to.be.an('array')
+        })
+      })
+
+      it('returns HTTP 401 for request with invalid Basic Auth credentials on /redfish/v1/Systems', () => {
+        cy.request({
+          method: 'GET',
+          url: `${redfishUrl()}/redfish/v1/Systems`,
+          headers: { Authorization: `Basic ${btoa('invalid_user:invalid_password')}` },
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.eq(httpCodes.UNAUTHORIZED)
+        })
+      })
+    }
+  )
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error Handling — invalid endpoint (Postman #71)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Error Handling - Invalid Endpoint', () => {
+  context('TC_ERROR_HANDLING_INVALID_ENDPOINT - GET to an undefined Redfish path returns 404 Not Found', () => {
+    it('returns HTTP 404 for GET to an undefined Redfish endpoint /redfish/v1/InvalidEndpoint', () => {
+      cy.request({
+        method: 'GET',
+        url: `${redfishUrl()}/redfish/v1/InvalidEndpoint`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.eq(404)
+      })
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Complete BIOS Reset Flow — PATCH BiosSetup then POST ForceRestart (Postman #58)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Redfish Complete BIOS Reset Flow', () => {
+  context(
+    'TC_SYSTEM_BIOS_RESET_FLOW - set BiosSetup boot override via PATCH then POST ForceRestart returns 202 Task or device-unavailable',
+    () => {
+      it('PATCH BiosSetup boot override then POST ForceRestart returns HTTP 202 Task or device-unavailable code', () => {
+        // Step 1: set boot override to BiosSetup
+        cy.request({
+          method: 'PATCH',
+          url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}`,
+          headers: basicAuthHeaders(),
+          body: systemsFixtures.patchBootSettings.biosSetup,
+          failOnStatusCode: false
+        }).then((patchResponse) => {
+          // Only proceed to reset if PATCH succeeded
+          if (patchResponse.status === httpCodes.SUCCESS) {
+            cy.request({
+              method: 'POST',
+              url: `${redfishUrl()}/redfish/v1/Systems/${systemId()}/Actions/ComputerSystem.Reset`,
+              headers: basicAuthHeaders(),
+              body: systemsFixtures.reset.forceRestart,
+              failOnStatusCode: false
+            }).then((resetResponse) => {
+              expect(resetResponse.status).to.be.oneOf([
+                202,
+                409,
+                404,
+                httpCodes.INTERNAL_SERVER_ERROR
+              ])
+              if (resetResponse.status === 202) {
+                expect(resetResponse.body['@odata.type']).to.include('Task')
+                expect(resetResponse.body).to.have.property('TaskState', 'Completed')
+                expect(resetResponse.body).to.have.property('TaskStatus', 'OK')
+                expect(resetResponse.headers).to.have.property('location')
+                expect(resetResponse.headers.location).to.include('/redfish/v1/TaskService/Tasks/')
+              }
+            })
+          } else {
+            cy.log(`Skipping reset step: PATCH returned ${patchResponse.status} (device not available)`)
+          }
+        })
+      })
+    }
+  )
+})

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "cypress-install": "cypress install",
     "cypress": "cypress open",
     "cy-runner": "cypress run",
+    "cy-runner:redfish": "cypress run --config-file cypress.redfish.config.ts",
+    "cy-runner:all": "cypress run --config-file cypress.config.ts && cypress run --config-file cypress.redfish.config.ts",
+    "cy-open:redfish": "cypress open --config-file cypress.redfish.config.ts",
+    "cy-open:all": "cypress open --config-file cypress.config.ts",
     "lint:cypress": "eslint ./cypress"
   },
   "private": true,


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?
- Add Redfish test specs into Cypress framework 

## Anything the reviewer should know when reviewing this PR?
- commands: 
  - on AMT Device (ISOLATE=N):
    - without Device GUID (it auto-select the first device to run the tests): 
      - npm run cy-runner:redfish -- --spec "cypress/e2e/integration-redfish/**/*.spec.ts" --env ISOLATE=N
    - with Device GUID (to run on a specify AMT device): 
      - npm run cy-runner:redfish -- --spec "cypress/e2e/integration-redfish/**/*.spec.ts" --env ISOLATE=N,REDFISH_SYSTEM_ID=<AMT_Device_GUID>
  - isolated run (ISOLATE=Y):
    - npm run cy-runner:redfish -- --spec "cypress/e2e/integration-redfish/**/*.spec.ts" --env ISOLATE=Y,REDFISH_SYSTEM_ID=<AMT_Device_GUID-DOES_NOT_NEED_A_REAL_GUID>

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
