### PR TITLE
fix: require password when switching random to static on edit

### DIFF
--- a/src/app/profiles/profile-detail/profile-detail.component.spec.ts
+++ b/src/app/profiles/profile-detail/profile-detail.component.spec.ts
@@ -147,6 +147,21 @@ describe('ProfileDetailComponent', () => {
     TestBed.resetTestingModule()
   })
 
+  // Re-load the edit profile through the real capture path (getRecord -> getAmtProfile) so tests
+  // exercise how originals are derived rather than poking private fields directly.
+  const loadProfileForEdit = (overrides: Partial<Profile>): void => {
+    profileSpy.and.returnValue(
+      of({
+        profileName: 'profile',
+        activation: 'acmactivate',
+        generateRandomPassword: true,
+        generateRandomMEBxPassword: true,
+        ...overrides
+      } as any)
+    )
+    component.getAmtProfile('profile')
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy()
     expect(ciraGetDataSpy).toHaveBeenCalled()
@@ -231,20 +246,17 @@ describe('ProfileDetailComponent', () => {
     expect(routerSpy).toHaveBeenCalled()
   })
 
-  it('should not require passwords on update', () => {
-    component.profileForm.patchValue({
-      activation: 'acmactivate',
-      generateRandomPassword: false,
-      generateRandomMEBxPassword: false
-    })
-
+  it('should not require the AMT password on edit when a static password is already stored', () => {
+    // Default mock profile has generateRandomPassword: false, so a static secret is stored server-side.
+    component.generateRandomPasswordChange(false)
     expect(component.profileForm.controls.amtPassword.hasValidator(Validators.required)).toBeFalse()
-    expect(component.profileForm.controls.mebxPassword.hasValidator(Validators.required)).toBeFalse()
   })
 
   it('should omit empty passwords from the update payload', () => {
     const routerSpy = spyOn(component.router, 'navigate')
 
+    // Both secrets already stored statically server-side, so blank fields preserve them.
+    loadProfileForEdit({ activation: 'acmactivate', generateRandomPassword: false, generateRandomMEBxPassword: false })
     component.profileForm.patchValue({
       profileName: 'profile',
       activation: 'acmactivate',
@@ -702,6 +714,113 @@ describe('ProfileDetailComponent', () => {
 
     expect(profileUpdateSpy).toHaveBeenCalled()
     expect(routerSpy).not.toHaveBeenCalled()
+  })
+
+  // Password preservation on edit: a blank field is allowed only when a static
+  // secret already exists server-side; switching random -> static requires one.
+  describe('Password preservation on edit', () => {
+    it('should capture the original password settings when loading a profile to edit', () => {
+      const profileData = {
+        profileName: 'acm-static',
+        activation: 'acmactivate',
+        generateRandomPassword: true,
+        generateRandomMEBxPassword: false
+      } as any
+      profileSpy.and.returnValue(of(profileData))
+
+      component.getAmtProfile('acm-static')
+
+      expect(component['originalGenerateRandomPassword']).toBeTrue()
+      expect(component['originalGenerateRandomMEBxPassword']).toBeFalse()
+      expect(component['originalActivation']).toBe('acmactivate')
+    })
+
+    it('should require the AMT password when switching from random to static on edit', () => {
+      loadProfileForEdit({ generateRandomPassword: true })
+      component.generateRandomPasswordChange(false)
+      expect(component.profileForm.controls.amtPassword.hasValidator(Validators.required)).toBeTrue()
+    })
+
+    it('should require the MEBx password when switching from random to static (acm) on edit', () => {
+      // Default mock profile has generateRandomMEBxPassword: true (no stored MEBx secret).
+      component.profileForm.controls.activation.setValue('acmactivate')
+      component.generateRandomMEBxPasswordChange(false)
+      expect(component.profileForm.controls.mebxPassword.hasValidator(Validators.required)).toBeTrue()
+    })
+
+    it('should not require the MEBx password on edit when a static acm secret is already stored', () => {
+      loadProfileForEdit({ activation: 'acmactivate', generateRandomMEBxPassword: false })
+      component.profileForm.controls.activation.setValue('acmactivate')
+      component.generateRandomMEBxPasswordChange(false)
+      expect(component.profileForm.controls.mebxPassword.hasValidator(Validators.required)).toBeFalse()
+    })
+
+    it('should require the MEBx password when an existing ccm profile switches to acm', () => {
+      // Static MEBx secrets are only stored for acm, so a ccm origin has none to preserve.
+      loadProfileForEdit({ activation: 'ccmactivate', generateRandomMEBxPassword: false })
+      component.profileForm.controls.activation.setValue('acmactivate')
+      component.generateRandomMEBxPasswordChange(false)
+      expect(component.profileForm.controls.mebxPassword.hasValidator(Validators.required)).toBeTrue()
+    })
+
+    it('should recompute MEBx validity immediately when switching activation from ccm to acm', () => {
+      // ccm origin has no stored MEBx secret, so acm + empty MEBx must be invalid right away (no stale valid state).
+      loadProfileForEdit({ activation: 'ccmactivate', generateRandomMEBxPassword: false })
+      component.profileForm.controls.mebxPassword.setValue('')
+      component.profileForm.controls.generateRandomMEBxPassword.setValue(false)
+
+      component.activationChange('acmactivate')
+
+      expect(component.profileForm.controls.mebxPassword.hasValidator(Validators.required)).toBeTrue()
+      expect(component.profileForm.controls.mebxPassword.valid).toBeFalse()
+    })
+
+    it('should block submit when switching to a static AMT password but leaving the field blank', () => {
+      const routerSpy = spyOn(component.router, 'navigate')
+
+      loadProfileForEdit({ generateRandomPassword: true })
+      component.profileForm.patchValue({
+        profileName: 'profile',
+        activation: 'acmactivate',
+        generateRandomPassword: false,
+        amtPassword: '',
+        generateRandomMEBxPassword: false,
+        mebxPassword: 'Password123',
+        dhcpEnabled: true,
+        ciraConfigName: 'config1'
+      })
+      component.confirm()
+
+      expect(component.profileForm.controls.amtPassword.hasValidator(Validators.required)).toBeTrue()
+      expect(profileUpdateSpy).not.toHaveBeenCalled()
+      expect(routerSpy).not.toHaveBeenCalled()
+    })
+
+    it('should surface the server error when the API rejects an omitted password', () => {
+      // The UI allows omitting both passwords (static secrets stored server-side), but if the API
+      // contract drifts and rejects the PATCH, the user must see why rather than a silent no-op.
+      const serverError = ['MEBx password is required for acmactivate']
+      profileUpdateSpy.and.returnValue(throwError(() => serverError))
+      loadProfileForEdit({
+        activation: 'acmactivate',
+        generateRandomPassword: false,
+        generateRandomMEBxPassword: false
+      })
+      component.profileForm.patchValue({
+        profileName: 'profile',
+        activation: 'acmactivate',
+        generateRandomPassword: false,
+        generateRandomMEBxPassword: false,
+        amtPassword: '',
+        mebxPassword: '',
+        dhcpEnabled: true,
+        ciraConfigName: 'config1'
+      })
+      component.confirm()
+
+      expect(profileUpdateSpy).toHaveBeenCalled()
+      expect(component.errorMessages()).toEqual(serverError)
+    })
   })
 
   // Proxy Configuration Tests

--- a/src/app/profiles/profile-detail/profile-detail.component.ts
+++ b/src/app/profiles/profile-detail/profile-detail.component.ts
@@ -47,7 +47,9 @@ import { StaticCIRAWarningComponent } from '../../shared/static-cira-warning/sta
 // Models and constants
 import { CIRAConfig, IEEE8021xConfig } from '../../../models/models'
 import {
+  ACM_ACTIVATION,
   ActivationModes,
+  CCM_ACTIVATION,
   Profile,
   proxyConfig,
   TlsModes,
@@ -163,6 +165,12 @@ export class ProfileDetailComponent implements OnInit {
   public readonly amtInputType = signal<'password' | 'text'>('password')
   public readonly mebxInputType = signal<'password' | 'text'>('password')
 
+  // Original server-side password settings (captured on edit load) to decide if a blank field preserves a stored secret or must be re-entered. Mirrors RPS edit.ts.
+  // Default to the strict direction (treat as random/not-stored) so the brief async-load window before getAmtProfile populates these errs toward requiring a password.
+  private originalGenerateRandomPassword = true
+  private originalGenerateRandomMEBxPassword = true
+  private originalActivation = ''
+
   // Computed properties
   public readonly showIEEE8021xConfigurations = computed(() => this.iee8021xConfigurations().length > 0)
   public readonly showWirelessConfigurations = computed(() => this.wirelessConfigurations().length > 0)
@@ -241,17 +249,27 @@ export class ProfileDetailComponent implements OnInit {
     }
   }
 
-  // Passwords are optional on edit (the GET response never returns them).
-  private setPasswordRequiredValidator(control: FormControl<string | null>): void {
-    if (this.isEdit()) {
+  // Blank allowed only when editing a profile with a stored static secret (RPS reuses it); otherwise required: on create and on random -> static switches.
+  private setPasswordRequiredValidator(control: FormControl<string | null>, canPreserveStoredSecret: boolean): void {
+    if (this.isEdit() && canPreserveStoredSecret) {
       control.clearValidators()
     } else {
       control.setValidators(Validators.required)
     }
   }
 
+  // True when the AMT password is already stored statically server-side.
+  private canPreserveStoredAmtPassword(): boolean {
+    return this.originalGenerateRandomPassword === false
+  }
+
+  // True when the MEBx password is already stored statically server-side (only for ACM profiles not using a random password).
+  private canPreserveStoredMebxPassword(): boolean {
+    return this.originalGenerateRandomMEBxPassword === false && this.originalActivation === ACM_ACTIVATION
+  }
+
   activationChange(value: string): void {
-    if (value === 'ccmactivate') {
+    if (value === CCM_ACTIVATION) {
       this.profileForm.controls.userConsent.disable()
       this.profileForm.controls.userConsent.setValue('All')
       this.profileForm.controls.userConsent.clearValidators()
@@ -262,11 +280,15 @@ export class ProfileDetailComponent implements OnInit {
       this.profileForm.controls.generateRandomMEBxPassword.disable()
     } else {
       this.profileForm.controls.mebxPassword.enable()
-      this.setPasswordRequiredValidator(this.profileForm.controls.mebxPassword)
+      this.setPasswordRequiredValidator(this.profileForm.controls.mebxPassword, this.canPreserveStoredMebxPassword())
       this.profileForm.controls.userConsent.enable()
       this.profileForm.controls.userConsent.setValidators(Validators.required)
       this.profileForm.controls.generateRandomMEBxPassword.enable()
     }
+    // setValidators/clearValidators don't recompute validity, so refresh the touched controls to avoid a stale valid state.
+    this.profileForm.controls.mebxPassword.updateValueAndValidity()
+    this.profileForm.controls.userConsent.updateValueAndValidity()
+    this.profileForm.controls.generateRandomMEBxPassword.updateValueAndValidity()
   }
 
   getAmtProfile(name: string): void {
@@ -278,6 +300,11 @@ export class ProfileDetailComponent implements OnInit {
         next: (data) => {
           this.pageTitle.set(data.profileName)
           this.tags.set(data.tags || [])
+          // Capture original password settings before patchValue triggers the subscriptions that read them.
+          // Treat anything other than an explicit `false` (including nullish/legacy rows) as random/not-stored so a blank field can never silently preserve — and then wipe — a secret we can't confirm exists.
+          this.originalGenerateRandomPassword = data.generateRandomPassword !== false
+          this.originalGenerateRandomMEBxPassword = data.generateRandomMEBxPassword !== false
+          this.originalActivation = data.activation ?? ''
           this.profileForm.patchValue(data as any)
           this.selectedWifiConfigs.set(data.wifiConfigs ?? [])
           // Ensure proxy configs have proper priorities
@@ -355,7 +382,7 @@ export class ProfileDetailComponent implements OnInit {
       this.profileForm.controls.amtPassword.clearValidators()
     } else {
       this.profileForm.controls.amtPassword.enable()
-      this.setPasswordRequiredValidator(this.profileForm.controls.amtPassword)
+      this.setPasswordRequiredValidator(this.profileForm.controls.amtPassword, this.canPreserveStoredAmtPassword())
     }
     this.profileForm.controls.amtPassword.updateValueAndValidity()
   }
@@ -365,9 +392,9 @@ export class ProfileDetailComponent implements OnInit {
       this.profileForm.controls.mebxPassword.disable()
       this.profileForm.controls.mebxPassword.setValue(null)
       this.profileForm.controls.mebxPassword.clearValidators()
-    } else if (this.profileForm.controls.activation.value === 'acmactivate') {
+    } else if (this.profileForm.controls.activation.value === ACM_ACTIVATION) {
       this.profileForm.controls.mebxPassword.enable()
-      this.setPasswordRequiredValidator(this.profileForm.controls.mebxPassword)
+      this.setPasswordRequiredValidator(this.profileForm.controls.mebxPassword, this.canPreserveStoredMebxPassword())
     }
     this.profileForm.controls.mebxPassword.updateValueAndValidity()
   }
@@ -681,7 +708,7 @@ export class ProfileDetailComponent implements OnInit {
   private createProfileForm() {
     return this.fb.group({
       profileName: ['', Validators.required],
-      activation: ['acmactivate', Validators.required],
+      activation: [ACM_ACTIVATION, Validators.required],
       generateRandomPassword: [true, Validators.required],
       amtPassword: [{ value: null as string | null, disabled: true }],
       generateRandomMEBxPassword: [true, Validators.required],

--- a/src/app/profiles/profiles.constants.ts
+++ b/src/app/profiles/profiles.constants.ts
@@ -5,9 +5,13 @@
 
 import { FormOption } from '../../models/models'
 
+// Activation mode values as understood by RPS. Use these instead of bare string literals.
+export const ACM_ACTIVATION = 'acmactivate'
+export const CCM_ACTIVATION = 'ccmactivate'
+
 export const ActivationModes: FormOption<string>[] = [
-  { value: 'acmactivate', label: 'profileDetail.activationModeAdmin.value' },
-  { value: 'ccmactivate', label: 'profileDetail.activationModeClient.value' }
+  { value: ACM_ACTIVATION, label: 'profileDetail.activationModeAdmin.value' },
+  { value: CCM_ACTIVATION, label: 'profileDetail.activationModeClient.value' }
 ]
 
 export const UserConsentModes: FormOption<string>[] = [


### PR DESCRIPTION
AMT/MEBx password fields were optional on every edit, so unchecking "Generate Random" and submitting a blank field silently preserved the old random setting instead of switching the profile to a static password.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
