### PR TITLE
feat: toggle CIRA tab from server features API

### DIFF
--- a/src/app/core/navbar/navbar.component.html
+++ b/src/app/core/navbar/navbar.component.html
@@ -17,15 +17,17 @@
     <mat-icon matListItemIcon>wifi</mat-icon
     ><span i18n="navlink">{{ 'wireless.header.wirelessTitle.value' | translate }}</span>
   </a>
-  <a
-    mat-list-item
-    routerLink="/ciraconfigs"
-    routerLinkActive="active"
-    [matTooltipPosition]="'right'"
-    [matTooltip]="ciraTitle">
-    <mat-icon matListItemIcon>settings_ethernet</mat-icon
-    ><span i18n="navlink">{{ 'configs.header.ciraTitle.value' | translate }}</span>
-  </a>
+  @if (ciraEnabled()) {
+    <a
+      mat-list-item
+      routerLink="/ciraconfigs"
+      routerLinkActive="active"
+      [matTooltipPosition]="'right'"
+      [matTooltip]="ciraTitle">
+      <mat-icon matListItemIcon>settings_ethernet</mat-icon
+      ><span i18n="navlink">{{ 'configs.header.ciraTitle.value' | translate }}</span>
+    </a>
+  }
   @if (cloudMode === true) {
     <a mat-list-item routerLink="/proxy-configs" routerLinkActive="active">
       <mat-icon matListItemIcon>router</mat-icon

--- a/src/app/core/navbar/navbar.component.spec.ts
+++ b/src/app/core/navbar/navbar.component.spec.ts
@@ -9,18 +9,22 @@ import { MatIconModule } from '@angular/material/icon'
 import { MatListModule } from '@angular/material/list'
 import { NavbarComponent } from './navbar.component'
 import { ActivatedRoute, RouterModule } from '@angular/router'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { provideHttpClient } from '@angular/common/http'
 import { provideHttpClientTesting } from '@angular/common/http/testing'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { TRANSLATE_HTTP_LOADER_CONFIG } from '@ngx-translate/http-loader'
+import { ServerFeaturesService } from '../../server-features.service'
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent
   let fixture: ComponentFixture<NavbarComponent>
   let translate: TranslateService
+  let serverFeaturesSpy: jasmine.SpyObj<ServerFeaturesService>
 
   beforeEach(() => {
+    serverFeaturesSpy = jasmine.createSpyObj('ServerFeaturesService', ['getFeatures'])
+    serverFeaturesSpy.getFeatures.and.returnValue(of({ ciraEnabled: true }))
     TestBed.configureTestingModule({
       imports: [
         MatIconModule,
@@ -33,6 +37,7 @@ describe('NavbarComponent', () => {
       providers: [
         { provide: ActivatedRoute, useValue: { params: of({ id: 'guid' }) } },
         { provide: TRANSLATE_HTTP_LOADER_CONFIG, useValue: { prefix: '/assets/i18n/', suffix: '.json' } },
+        { provide: ServerFeaturesService, useValue: serverFeaturesSpy },
         TranslateService,
         provideHttpClient(),
         provideHttpClientTesting()
@@ -42,7 +47,6 @@ describe('NavbarComponent', () => {
     component = fixture.componentInstance
     translate = TestBed.inject(TranslateService)
     translate.setFallbackLang('en')
-    fixture.detectChanges()
   })
 
   afterEach(() => {
@@ -51,5 +55,37 @@ describe('NavbarComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('should not query server features in cloud mode and keep the CIRA tab enabled', () => {
+    component.cloudMode = true
+    serverFeaturesSpy.getFeatures.calls.reset()
+    component.ngOnInit()
+    expect(serverFeaturesSpy.getFeatures).not.toHaveBeenCalled()
+    expect(component.ciraEnabled()).toBeTrue()
+  })
+
+  it('should disable the CIRA tab when the server reports CIRA disabled (enterprise mode)', () => {
+    component.cloudMode = false
+    serverFeaturesSpy.getFeatures.and.returnValue(of({ ciraEnabled: false }))
+    fixture.detectChanges()
+    expect(serverFeaturesSpy.getFeatures).toHaveBeenCalled()
+    expect(component.ciraEnabled()).toBeFalse()
+    expect(fixture.nativeElement.querySelector('a[routerlink="/ciraconfigs"]')).toBeNull()
+  })
+
+  it('should enable the CIRA tab when the server reports CIRA enabled (enterprise mode)', () => {
+    component.cloudMode = false
+    serverFeaturesSpy.getFeatures.and.returnValue(of({ ciraEnabled: true }))
+    fixture.detectChanges()
+    expect(component.ciraEnabled()).toBeTrue()
+    expect(fixture.nativeElement.querySelector('a[routerlink="/ciraconfigs"]')).not.toBeNull()
+  })
+
+  it('should fail open and keep the CIRA tab enabled when the features call errors (enterprise mode)', () => {
+    component.cloudMode = false
+    serverFeaturesSpy.getFeatures.and.returnValue(throwError(() => new Error('failed')))
+    component.ngOnInit()
+    expect(component.ciraEnabled()).toBeTrue()
   })
 })

--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
-import { Component, inject } from '@angular/core'
+import { Component, OnInit, inject, signal } from '@angular/core'
 import { environment } from '../../../environments/environment'
 import { MatIcon } from '@angular/material/icon'
 import { RouterLink, RouterLinkActive } from '@angular/router'
@@ -11,6 +11,7 @@ import { MatDivider } from '@angular/material/divider'
 import { MatNavList, MatListItem, MatListItemIcon } from '@angular/material/list'
 import { MatTooltip } from '@angular/material/tooltip'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { ServerFeaturesService } from '../../server-features.service'
 
 @Component({
   selector: 'app-navbar',
@@ -28,14 +29,30 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core'
     TranslateModule
   ]
 })
-export class NavbarComponent {
+export class NavbarComponent implements OnInit {
   cloudMode = environment.cloud
   showSubNav = false
+  // CIRA tab visibility. Cloud (MPS+RPS) always shows it; in enterprise it is
+  // driven by the Console server's APP_DISABLE_CIRA setting (fetched on init).
+  // Start from cloudMode so enterprise hides the tab until the API responds,
+  // avoiding a flash of the tab when the server reports CIRA disabled.
+  ciraEnabled = signal(this.cloudMode)
   private readonly translate = inject(TranslateService)
+  private readonly serverFeaturesService = inject(ServerFeaturesService)
+
+  ngOnInit(): void {
+    if (this.cloudMode === false) {
+      this.serverFeaturesService.getFeatures().subscribe({
+        next: (features) => this.ciraEnabled.set(features.ciraEnabled),
+        // Fail open: if the features call fails, keep the CIRA tab visible.
+        error: () => this.ciraEnabled.set(true)
+      })
+    }
+  }
 
   get ciraTitle(): string {
-    return this.cloudMode === false
-      ? this.translate.instant('configs.header.noCiraTitle.value')
-      : this.translate.instant('configs.header.ciraTitle.value')
+    return this.ciraEnabled()
+      ? this.translate.instant('configs.header.ciraTitle.value')
+      : this.translate.instant('configs.header.noCiraTitle.value')
   }
 }

--- a/src/app/profiles/profile-detail/profile-detail.component.html
+++ b/src/app/profiles/profile-detail/profile-detail.component.html
@@ -327,28 +327,43 @@
               <mat-radio-button
                 data-cy="radio-cira"
                 [value]="connectionMode.cira"
-                [disabled]="ciraConfigurations().length === 0">
+                [disabled]="!ciraEnabled() || ciraConfigurations().length === 0">
                 {{ 'profileDetail.ciraCloud.value' | translate }}
-                @if (ciraConfigurations().length === 0) {
+                @if (!ciraEnabled()) {
+                  <span>{{ 'profileDetail.ciraDisabledOption.value' | translate }}</span>
+                } @else if (ciraConfigurations().length === 0) {
                   <span>{{ 'profileDetail.noCiraConfigs.value' | translate }}</span>
                 }
               </mat-radio-button>
             </p>
             @if (profileForm.get('connectionMode')?.value === 'CIRA') {
-              <mat-form-field class="flex flex-1">
-                <mat-label>{{ 'profileDetail.ciraConfiguration.value' | translate }}</mat-label>
-                <mat-select formControlName="ciraConfigName">
-                  @for (cc of ciraConfigurations(); track cc) {
-                    <mat-option [value]="cc.configName">{{ cc.configName }} </mat-option>
-                  }
-                </mat-select>
-                <mat-hint>
-                  @if (profileForm.get('ciraConfigName')?.value === null) {
-                    <span>{{ 'profileDetail.noConfigSelected.value' | translate }}</span>
-                  }
-                  {{ 'profileDetail.ciraConfigHint.value' | translate }}
-                </mat-hint>
-              </mat-form-field>
+              @if (ciraEnabled()) {
+                <mat-form-field class="flex flex-1">
+                  <mat-label>{{ 'profileDetail.ciraConfiguration.value' | translate }}</mat-label>
+                  <mat-select formControlName="ciraConfigName">
+                    @for (cc of ciraConfigurations(); track cc) {
+                      <mat-option [value]="cc.configName">{{ cc.configName }} </mat-option>
+                    }
+                  </mat-select>
+                  <mat-hint>
+                    @if (profileForm.get('ciraConfigName')?.value === null) {
+                      <span>{{ 'profileDetail.noConfigSelected.value' | translate }}</span>
+                    }
+                    {{ 'profileDetail.ciraConfigHint.value' | translate }}
+                  </mat-hint>
+                </mat-form-field>
+              } @else {
+                <!-- CIRA disabled on this server but the profile still references a CIRA config.
+                     Show it read-only with a warning and let the user switch to TLS/Direct. -->
+                <p class="error-messages-container">
+                  <mat-icon color="warn">warning</mat-icon>
+                  <span class="error-messages">{{ 'profileDetail.ciraDisabledWarning.value' | translate }}</span>
+                </p>
+                <mat-form-field class="flex flex-1">
+                  <mat-label>{{ 'profileDetail.ciraConfiguration.value' | translate }}</mat-label>
+                  <input matInput formControlName="ciraConfigName" readonly />
+                </mat-form-field>
+              }
             }
           </fieldset>
           <fieldset>

--- a/src/app/profiles/profile-detail/profile-detail.component.spec.ts
+++ b/src/app/profiles/profile-detail/profile-detail.component.spec.ts
@@ -14,6 +14,7 @@ import { WirelessService } from '../../wireless/wireless.service'
 import { ProfilesService } from '../profiles.service'
 import { IEEE8021xService } from '../../ieee8021x/ieee8021x.service'
 import { ProxyConfigsService } from '../../proxy-configs/proxy-configs.service'
+import { ServerFeaturesService } from '../../server-features.service'
 import { ProfileDetailComponent } from './profile-detail.component'
 import { Profile } from '../profiles.constants'
 import { MatChipInputEvent } from '@angular/material/chips'
@@ -58,6 +59,7 @@ describe('ProfileDetailComponent', () => {
   let ieee8021xGetDataSpy: jasmine.Spy
   let wirelessGetDataSpy: jasmine.Spy
   let proxyGetDataSpy: jasmine.Spy
+  let serverFeaturesGetFeaturesSpy: jasmine.Spy
   // let tlsConfigSpy: jasmine.Spy
   let translate: TranslateService
 
@@ -76,6 +78,7 @@ describe('ProfileDetailComponent', () => {
     const ieee8021xService = jasmine.createSpyObj('IEEE8021xService', ['getData'])
     const wirelessService = jasmine.createSpyObj('WirelessService', ['getData'])
     const proxyConfigsService = jasmine.createSpyObj('ProxyConfigsService', ['getData'])
+    const serverFeaturesService = jasmine.createSpyObj('ServerFeaturesService', ['getFeatures'])
     // const tlsService = jasmine.createSpyObj('TLSService', ['getData'])
     const profileResponse = {
       profileName: 'profile1',
@@ -103,6 +106,7 @@ describe('ProfileDetailComponent', () => {
     proxyGetDataSpy = proxyConfigsService.getData.and.returnValue(
       of({ data: mockProxyConfigs, totalCount: mockProxyConfigs.length })
     )
+    serverFeaturesGetFeaturesSpy = serverFeaturesService.getFeatures.and.returnValue(of({ ciraEnabled: true }))
     // tlsConfigSpy = tlsService.getData.and.returnValue(of({ data: [], totalCount: 0 }))
     TestBed.configureTestingModule({
       imports: [
@@ -120,6 +124,7 @@ describe('ProfileDetailComponent', () => {
         { provide: IEEE8021xService, useValue: ieee8021xService },
         { provide: WirelessService, useFactory: () => wirelessService },
         { provide: ProxyConfigsService, useValue: proxyConfigsService },
+        { provide: ServerFeaturesService, useValue: serverFeaturesService },
         // { provide: TLSService, useValue: tlsService },
         {
           provide: ActivatedRoute,
@@ -820,6 +825,62 @@ describe('ProfileDetailComponent', () => {
 
       expect(profileUpdateSpy).toHaveBeenCalled()
       expect(component.errorMessages()).toEqual(serverError)
+    })
+  })
+
+  // CIRA gating in enterprise mode (driven by the Console server's APP_DISABLE_CIRA setting).
+  describe('CIRA gating (enterprise mode)', () => {
+    const originalCloud = environment.cloud
+
+    // Re-create the component in enterprise mode so initializeData() takes the
+    // server-features branch instead of the cloud branch.
+    const createEnterpriseComponent = (): ProfileDetailComponent => {
+      environment.cloud = false
+      const enterpriseFixture = TestBed.createComponent(ProfileDetailComponent)
+      enterpriseFixture.detectChanges()
+      return enterpriseFixture.componentInstance
+    }
+
+    afterEach(() => {
+      environment.cloud = originalCloud
+    })
+
+    it('should not fetch CIRA configs when the server reports CIRA disabled', () => {
+      serverFeaturesGetFeaturesSpy.and.returnValue(of({ ciraEnabled: false }))
+      ciraGetDataSpy.calls.reset()
+
+      createEnterpriseComponent()
+
+      expect(serverFeaturesGetFeaturesSpy).toHaveBeenCalled()
+      expect(ciraGetDataSpy).not.toHaveBeenCalled()
+    })
+
+    it('should expose ciraEnabled() === false after the features call resolves with CIRA disabled', () => {
+      serverFeaturesGetFeaturesSpy.and.returnValue(of({ ciraEnabled: false }))
+
+      const enterpriseComponent = createEnterpriseComponent()
+
+      expect(enterpriseComponent.ciraEnabled()).toBeFalse()
+    })
+
+    it('should fetch CIRA configs when the server reports CIRA enabled', () => {
+      serverFeaturesGetFeaturesSpy.and.returnValue(of({ ciraEnabled: true }))
+      ciraGetDataSpy.calls.reset()
+
+      const enterpriseComponent = createEnterpriseComponent()
+
+      expect(ciraGetDataSpy).toHaveBeenCalled()
+      expect(enterpriseComponent.ciraEnabled()).toBeTrue()
+    })
+
+    it('should fail open and fetch CIRA configs when the features call errors', () => {
+      serverFeaturesGetFeaturesSpy.and.returnValue(throwError(() => new Error('nope')))
+      ciraGetDataSpy.calls.reset()
+
+      const enterpriseComponent = createEnterpriseComponent()
+
+      expect(ciraGetDataSpy).toHaveBeenCalled()
+      expect(enterpriseComponent.ciraEnabled()).toBeTrue()
     })
   })
 

--- a/src/app/profiles/profile-detail/profile-detail.component.ts
+++ b/src/app/profiles/profile-detail/profile-detail.component.ts
@@ -39,6 +39,7 @@ import { ProfilesService } from '../profiles.service'
 import { WirelessService } from '../../wireless/wireless.service'
 import { IEEE8021xService } from '../../ieee8021x/ieee8021x.service'
 import { ProxyConfigsService } from '../../proxy-configs/proxy-configs.service'
+import { ServerFeaturesService } from '../../server-features.service'
 
 // Shared components
 import { RandomPassAlertComponent } from '../../shared/random-pass-alert/random-pass-alert.component'
@@ -133,6 +134,7 @@ export class ProfileDetailComponent implements OnInit {
   private readonly wirelessService = inject(WirelessService)
   private readonly ieee8021xService = inject(IEEE8021xService)
   private readonly proxyConfigsService = inject(ProxyConfigsService)
+  private readonly serverFeaturesService = inject(ServerFeaturesService)
   private readonly dialog = inject(MatDialog)
   private readonly translate = inject(TranslateService)
   public readonly router = inject(Router)
@@ -140,6 +142,11 @@ export class ProfileDetailComponent implements OnInit {
   NO_PROXY_CONFIGS = this.translate.instant(NO_PROXY_CONFIGS)
   // Computed properties and signals
   public readonly cloudMode = environment.cloud
+  // CIRA connection-mode availability. Cloud (MPS+RPS) always supports it; in
+  // enterprise it is driven by the Console server's APP_DISABLE_CIRA setting
+  // (fetched on init). Start from cloudMode so enterprise hides CIRA until the
+  // API responds, avoiding a flash when the server reports CIRA disabled.
+  public readonly ciraEnabled = signal(this.cloudMode)
   public readonly isLoading = signal(false)
   public readonly errorMessages = signal<string[]>([])
 
@@ -201,9 +208,24 @@ export class ProfileDetailComponent implements OnInit {
     this.getIEEE8021xConfigs()
     this.getWirelessConfigs()
     if (this.cloudMode) {
+      // Cloud always has CIRA; proxy configs are cloud-only too.
       this.getProxyConfigs()
+      this.getCiraConfigs()
+    } else {
+      // Enterprise: only fetch CIRA configs when the server reports CIRA enabled,
+      // otherwise the CIRA-configs endpoint 404s.
+      this.serverFeaturesService.getFeatures().subscribe({
+        next: (features) => {
+          this.ciraEnabled.set(features.ciraEnabled)
+          if (features.ciraEnabled) this.getCiraConfigs()
+        },
+        // Fail open: if the features call fails, assume CIRA is enabled.
+        error: () => {
+          this.ciraEnabled.set(true)
+          this.getCiraConfigs()
+        }
+      })
     }
-    this.getCiraConfigs()
   }
 
   private setupFormSubscriptions(): void {

--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -24,7 +24,17 @@
           <mat-header-cell *matHeaderCellDef style="flex: 1 1 0">
             {{ 'profiles.table.name.value' | translate }}
           </mat-header-cell>
-          <mat-cell *matCellDef="let element" style="flex: 1 1 0"> {{ element.profileName }} </mat-cell>
+          <mat-cell *matCellDef="let element" style="flex: 1 1 0">
+            {{ element.profileName }}
+            @if (!ciraEnabled() && element.ciraConfigName) {
+              <mat-icon
+                color="warn"
+                [matTooltip]="'profileDetail.ciraDisabledWarning.value' | translate"
+                style="font-size: 18px; height: 18px; width: 18px; vertical-align: middle; margin-left: 4px"
+                >warning</mat-icon
+              >
+            }
+          </mat-cell>
         </ng-container>
         <!-- network config Column -->
         <ng-container matColumnDef="networkConfig">

--- a/src/app/profiles/profiles.component.spec.ts
+++ b/src/app/profiles/profiles.component.spec.ts
@@ -10,20 +10,26 @@ import { of } from 'rxjs'
 
 import { ProfilesComponent } from './profiles.component'
 import { ProfilesService } from './profiles.service'
+import { ServerFeaturesService } from '../server-features.service'
 import { RouterModule } from '@angular/router'
 import { provideHttpClient } from '@angular/common/http'
 import { provideHttpClientTesting } from '@angular/common/http/testing'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { TRANSLATE_HTTP_LOADER_CONFIG } from '@ngx-translate/http-loader'
+import { environment } from '../../environments/environment'
 
 describe('ProfilesComponent', () => {
   let component: ProfilesComponent
   let fixture: ComponentFixture<ProfilesComponent>
   let getDataSpy: jasmine.Spy
   let deleteSpy: jasmine.Spy
+  let serverFeaturesServiceSpy: jasmine.SpyObj<ServerFeaturesService>
   let translate: TranslateService
 
   beforeEach(() => {
+    serverFeaturesServiceSpy = jasmine.createSpyObj('ServerFeaturesService', ['getFeatures'])
+    serverFeaturesServiceSpy.getFeatures.and.returnValue(of({ ciraEnabled: true }))
+
     const profilesService = jasmine.createSpyObj('ProfilesService', ['getData', 'delete'])
     getDataSpy = profilesService.getData.and.returnValue(
       of({
@@ -56,6 +62,7 @@ describe('ProfilesComponent', () => {
       ],
       providers: [
         { provide: ProfilesService, useValue: profilesService },
+        { provide: ServerFeaturesService, useValue: serverFeaturesServiceSpy },
         { provide: TRANSLATE_HTTP_LOADER_CONFIG, useValue: { prefix: '/assets/i18n/', suffix: '.json' } },
         TranslateService,
         provideHttpClient(),
@@ -122,5 +129,28 @@ describe('ProfilesComponent', () => {
     expect(component.paginator.pageSize).toBe(25)
     expect(component.paginator.pageIndex).toBe(0)
     expect(component.paginator.showFirstLastButtons).toBe(true)
+  })
+  it('should fetch features and set ciraEnabled false in enterprise mode when CIRA is disabled', () => {
+    // cloudMode is captured from environment.cloud at construction, so flip it
+    // to false and build a fresh component to exercise the enterprise fetch path.
+    const originalCloud = environment.cloud
+    ;(environment as { cloud: boolean }).cloud = false
+    serverFeaturesServiceSpy.getFeatures.calls.reset()
+    serverFeaturesServiceSpy.getFeatures.and.returnValue(of({ ciraEnabled: false }))
+
+    const enterpriseFixture = TestBed.createComponent(ProfilesComponent)
+    const enterpriseComponent = enterpriseFixture.componentInstance
+    enterpriseFixture.detectChanges()
+
+    expect(serverFeaturesServiceSpy.getFeatures).toHaveBeenCalled()
+    expect(enterpriseComponent.ciraEnabled()).toBeFalse()
+    ;(environment as { cloud: boolean }).cloud = originalCloud
+  })
+
+  it('should keep CIRA enabled in cloud mode without calling the features API', () => {
+    // Default test env is cloud (environment.cloud === true): no features call, CIRA stays on.
+    expect(component.cloudMode).toBeTrue()
+    expect(serverFeaturesServiceSpy.getFeatures).not.toHaveBeenCalled()
+    expect(component.ciraEnabled()).toBeTrue()
   })
 })

--- a/src/app/profiles/profiles.component.ts
+++ b/src/app/profiles/profiles.component.ts
@@ -14,6 +14,7 @@ import SnackbarDefaults from '../shared/config/snackBarDefault'
 import { ProfilesService } from './profiles.service'
 import { MatPaginator, PageEvent } from '@angular/material/paginator'
 import { Profile, TlsModes } from './profiles.constants'
+import { ToolkitPipe } from '../shared/pipes/toolkit.pipe'
 import {
   MatTable,
   MatColumnDef,
@@ -32,18 +33,18 @@ import { MatProgressBar } from '@angular/material/progress-bar'
 import { MatIcon } from '@angular/material/icon'
 import { MatButton, MatIconButton } from '@angular/material/button'
 import { MatToolbar } from '@angular/material/toolbar'
-import { ToolkitPipe } from '../shared/pipes/toolkit.pipe'
+import { MatTooltip } from '@angular/material/tooltip'
 import { environment } from '../../environments/environment'
 import { KeyDisplayDialogComponent } from './key-display-dialog/key-display-dialog.component'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { ExportDialogComponent } from './export-dialog/export-dialog.component'
+import { ServerFeaturesService } from '../server-features.service'
 
 @Component({
   selector: 'app-profiles',
   templateUrl: './profiles.component.html',
   styleUrls: ['./profiles.component.scss'],
   imports: [
-    ToolkitPipe,
     MatToolbar,
     MatButton,
     MatIcon,
@@ -62,6 +63,8 @@ import { ExportDialogComponent } from './export-dialog/export-dialog.component'
     MatRowDef,
     MatRow,
     MatPaginator,
+    MatTooltip,
+    ToolkitPipe,
     TranslateModule
   ]
 })
@@ -69,6 +72,7 @@ export class ProfilesComponent implements OnInit {
   // Dependency Injection
   private readonly dialog = inject(MatDialog)
   private readonly profilesService = inject(ProfilesService)
+  private readonly serverFeaturesService = inject(ServerFeaturesService)
   public readonly snackBar = inject(MatSnackBar)
   public readonly router = inject(Router)
   private readonly translate = inject(TranslateService)
@@ -76,7 +80,6 @@ export class ProfilesComponent implements OnInit {
   public profiles = new MatTableDataSource<Profile>()
   public readonly isLoading = signal(true)
   public totalCount = signal(0)
-  public readonly tlsModes = TlsModes
   public readonly displayedColumns: string[] = [
     'name',
     'networkConfig',
@@ -90,11 +93,23 @@ export class ProfilesComponent implements OnInit {
     count: 'true'
   }
   public readonly cloudMode = environment.cloud
+  // Assume CIRA is enabled until the server says otherwise, so the list never
+  // flashes false "CIRA disabled" warnings or blocks export during the brief
+  // window before getFeatures() resolves. Cloud always keeps it true; in
+  // enterprise the API flips it. Matches the fail-open error handler below.
+  public readonly ciraEnabled = signal(true)
+  public readonly tlsModes = TlsModes
 
   @ViewChild(MatPaginator) paginator!: MatPaginator
 
   ngOnInit(): void {
     this.getData(this.pageEvent)
+    if (this.cloudMode === false) {
+      this.serverFeaturesService.getFeatures().subscribe({
+        next: (features) => this.ciraEnabled.set(features.ciraEnabled),
+        error: () => this.ciraEnabled.set(true)
+      })
+    }
   }
 
   getData(pageEvent: PageEventOptions): void {
@@ -131,6 +146,13 @@ export class ProfilesComponent implements OnInit {
       return
     }
 
+    if (!this.ciraEnabled() && profile.ciraConfigName) {
+      const msg: string = this.translate.instant('profiles.ciraExportDisabled.value')
+
+      this.snackBar.open(msg, undefined, SnackbarDefaults.longError)
+      return
+    }
+
     if (profile.activation === 'acmactivate') {
       const dialogRef = this.dialog.open(ExportDialogComponent, {
         width: '400px',
@@ -163,10 +185,15 @@ export class ProfilesComponent implements OnInit {
 
         this.snackBar.open(msg, undefined, SnackbarDefaults.defaultSuccess)
       },
-      error: () => {
-        const msg: string = this.translate.instant('profiles.failExportProfile.value')
+      error: (err) => {
+        // Surface the backend reason (e.g. CIRA disabled) when present, like delete does.
+        if (err?.length > 0) {
+          this.snackBar.open(err.join(', '), undefined, SnackbarDefaults.longError)
+        } else {
+          const msg: string = this.translate.instant('profiles.failExportProfile.value')
 
-        this.snackBar.open(msg, undefined, SnackbarDefaults.defaultError)
+          this.snackBar.open(msg, undefined, SnackbarDefaults.defaultError)
+        }
       }
     })
   }
@@ -193,7 +220,7 @@ export class ProfilesComponent implements OnInit {
             },
             error: (err) => {
               if (err?.length > 0) {
-                this.snackBar.open(err as string, undefined, SnackbarDefaults.longError)
+                this.snackBar.open(err.join(', '), undefined, SnackbarDefaults.longError)
               } else {
                 const msg: string = this.translate.instant('profiles.failDeleteProfie.value')
 

--- a/src/app/server-features.service.spec.ts
+++ b/src/app/server-features.service.spec.ts
@@ -1,0 +1,76 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { TestBed } from '@angular/core/testing'
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing'
+import { provideHttpClient } from '@angular/common/http'
+import { ServerFeaturesService } from './server-features.service'
+import { AuthService } from './auth.service'
+import { environment } from '../environments/environment'
+import { ServerFeatures } from '../models/models'
+
+describe('ServerFeaturesService', () => {
+  let service: ServerFeaturesService
+  let httpMock: HttpTestingController
+  let authServiceSpy: jasmine.SpyObj<AuthService>
+
+  const mockEnvironment = { rpsServer: 'https://rps-server' }
+  const mockUrl = `${mockEnvironment.rpsServer}/api/v1/server/features`
+  let originalRpsServer: string
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['onError'])
+    originalRpsServer = environment.rpsServer
+    environment.rpsServer = mockEnvironment.rpsServer
+    TestBed.configureTestingModule({
+      providers: [
+        ServerFeaturesService,
+        { provide: AuthService, useValue: authServiceSpy },
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    })
+
+    service = TestBed.inject(ServerFeaturesService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    environment.rpsServer = originalRpsServer
+    httpMock.verify()
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  describe('getFeatures', () => {
+    it('should call the API and return the server features', () => {
+      const mockResponse: ServerFeatures = { ciraEnabled: true }
+
+      service.getFeatures().subscribe((response) => {
+        expect(response).toEqual(mockResponse)
+      })
+
+      const req = httpMock.expectOne(mockUrl)
+      expect(req.request.method).toBe('GET')
+      req.flush(mockResponse)
+    })
+
+    it('should handle errors', () => {
+      const mockError = { status: 500, statusText: 'Internal Server Error' }
+      authServiceSpy.onError.and.returnValue(['Error occurred'])
+
+      service.getFeatures().subscribe({
+        error: (error) => {
+          expect(error).toEqual(['Error occurred'])
+        }
+      })
+
+      const req = httpMock.expectOne(mockUrl)
+      req.flush(null, mockError)
+    })
+  })
+})

--- a/src/app/server-features.service.ts
+++ b/src/app/server-features.service.ts
@@ -1,0 +1,31 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { HttpClient } from '@angular/common/http'
+import { Injectable, inject } from '@angular/core'
+import { Observable, throwError } from 'rxjs'
+import { catchError } from 'rxjs/operators'
+import { environment } from '../environments/environment'
+import { ServerFeatures } from '../models/models'
+import { AuthService } from './auth.service'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServerFeaturesService {
+  private readonly authService = inject(AuthService)
+  private readonly http = inject(HttpClient)
+
+  private readonly url = `${environment.rpsServer}/api/v1/server/features`
+
+  getFeatures(): Observable<ServerFeatures> {
+    return this.http.get<ServerFeatures>(this.url).pipe(
+      catchError((err) => {
+        const errorMessages = this.authService.onError(err)
+        return throwError(errorMessages)
+      })
+    )
+  }
+}

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2145,6 +2145,14 @@
     "description": "تسمية حقل تكوين CIRA",
     "value": "تكوين CIRA"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA معطّل على هذا الخادم)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA معطّل على هذا الخادم. يستخدم هذا الملف الشخصي CIRA لاتصال الإدارة الخاص به ولن يعمل حتى تتم إعادة تمكين CIRA."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "تسمية قسم تكوين الاتصال",
     "value": "تكوين الاتصال المُوفر"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "رسالة للملفات الشخصية المحذوفة",
     "value": "تم حذف الملف الشخصي بنجاح"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA معطّل على هذا الخادم. يستخدم هذا الملف الشخصي CIRA لاتصال الإدارة الخاص به ولن يعمل حتى تتم إعادة تمكين CIRA."
   },
   "profiles.exportProfile": {
     "description": "رسالة للملفات الشخصية المصدرة",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2145,6 +2145,14 @@
     "description": "Bezeichnung für das CIRA-Konfigurationsfeld",
     "value": "CIRA-Konfiguration"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA ist auf diesem Server deaktiviert)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA ist auf diesem Server deaktiviert. Dieses Profil verwendet CIRA für seine Verwaltungsverbindung und funktioniert erst, wenn CIRA wieder aktiviert wird."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Bezeichnung für den Abschnitt zur Verbindungskonfiguration",
     "value": "Konfiguration der bereitgestellten Verbindung"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Nachricht für gelöschte Profile",
     "value": "Profil erfolgreich gelöscht"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA ist auf diesem Server deaktiviert. Dieses Profil verwendet CIRA für seine Verwaltungsverbindung und funktioniert erst, wenn CIRA wieder aktiviert wird."
   },
   "profiles.exportProfile": {
     "description": "Nachricht für exportierte Profile",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2343,6 +2343,14 @@
     "description": "Label for CIRA configuration field",
     "value": "CIRA Configuration"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA is disabled on this server)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA is disabled on this server. This profile uses CIRA for its management connection and won't work until CIRA is re-enabled."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Label for connection configuration section",
     "value": "Provisioned Connection Configuration"
@@ -2534,6 +2542,10 @@
   "profiles.deleteProfile": {
     "description": "Message for deleted profiles",
     "value": "Profile deleted successfully"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA is disabled on this server. This profile uses CIRA for its management connection and won't work until CIRA is re-enabled."
   },
   "profiles.exportProfile": {
     "description": "Message for exported profiles",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2145,6 +2145,14 @@
     "description": "Etiqueta para el campo de configuración CIRA.",
     "value": "Configuración de CIRA"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA está deshabilitado en este servidor)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA está deshabilitado en este servidor. Este perfil usa CIRA para su conexión de administración y no funcionará hasta que se vuelva a habilitar CIRA."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Etiqueta para la sección de configuración de la conexión.",
     "value": "Configuración de la conexión aprovisionada"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Mensaje para perfiles eliminados",
     "value": "Perfil eliminado correctamente."
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA está deshabilitado en este servidor. Este perfil usa CIRA para su conexión de administración y no funcionará hasta que se vuelva a habilitar CIRA."
   },
   "profiles.exportProfile": {
     "description": "Mensaje para perfiles exportados",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2145,6 +2145,14 @@
     "description": "CIRA-määrityskentän nimi",
     "value": "CIRA-konfiguraatio"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA on poistettu käytöstä tällä palvelimella)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA on poistettu käytöstä tällä palvelimella. Tämä profiili käyttää CIRAa hallintayhteyteensä eikä toimi, ennen kuin CIRA otetaan uudelleen käyttöön."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Yhteysasetusten osion nimike",
     "value": "Provisioitu yhteyden konfigurointi"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Viesti poistetuille profiileille",
     "value": "Profiili poistettu onnistuneesti"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA on poistettu käytöstä tällä palvelimella. Tämä profiili käyttää CIRAa hallintayhteyteensä eikä toimi, ennen kuin CIRA otetaan uudelleen käyttöön."
   },
   "profiles.exportProfile": {
     "description": "Viesti viedyille profiileille",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -2145,6 +2145,14 @@
     "description": "Étiquette pour le champ de configuration CIRA",
     "value": "Configuration CIRA"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA est désactivé sur ce serveur)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA est désactivé sur ce serveur. Ce profil utilise CIRA pour sa connexion de gestion et ne fonctionnera pas tant que CIRA n'est pas réactivé."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Étiquette pour la section de configuration de la connexion",
     "value": "Configuration de la connexion provisionnée"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Message pour les profils supprimés",
     "value": "Profil supprimé avec succès"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA est désactivé sur ce serveur. Ce profil utilise CIRA pour sa connexion de gestion et ne fonctionnera pas tant que CIRA n'est pas réactivé."
   },
   "profiles.exportProfile": {
     "description": "Message pour les profils exportés",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2145,6 +2145,14 @@
     "description": "תווית לשדה תצורת CIRA",
     "value": "תצורת CIRA"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA מושבת בשרת זה)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA מושבת בשרת זה. פרופיל זה משתמש ב-CIRA לחיבור הניהול שלו ולא יעבוד עד ש-CIRA יופעל מחדש."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "תווית לקטע תצורת חיבור",
     "value": "תצורת חיבור אספקת"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "הודעה לפרופילים שנמחקו",
     "value": "הפרופיל נמחק בהצלחה"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA מושבת בשרת זה. פרופיל זה משתמש ב-CIRA לחיבור הניהול שלו ולא יעבוד עד ש-CIRA יופעל מחדש."
   },
   "profiles.exportProfile": {
     "description": "הודעה לפרופילים מיוצאים",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2145,6 +2145,14 @@
     "description": "Etichetta per il campo di configurazione CIRA",
     "value": "Configurazione CIRA"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA è disabilitato su questo server)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA è disabilitato su questo server. Questo profilo utilizza CIRA per la sua connessione di gestione e non funzionerà finché CIRA non viene riabilitato."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Etichetta per la sezione di configurazione della connessione",
     "value": "Configurazione della connessione fornita"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Messaggio per i profili eliminati",
     "value": "Profilo eliminato con successo"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA è disabilitato su questo server. Questo profilo utilizza CIRA per la sua connessione di gestione e non funzionerà finché CIRA non viene riabilitato."
   },
   "profiles.exportProfile": {
     "description": "Messaggio per i profili esportati",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2145,6 +2145,14 @@
     "description": "CIRA設定フィールドのラベル",
     "value": "CIRA設定"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(このサーバーでは CIRA が無効になっています)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "このサーバーでは CIRA が無効になっています。このプロファイルは管理接続に CIRA を使用しているため、CIRA が再度有効になるまで機能しません。"
+  },
   "profileDetail.connectionConfiguration": {
     "description": "接続設定セクションのラベル",
     "value": "プロビジョニング済み接続設定"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "削除されたプロフィールに関するメッセージ",
     "value": "プロファイルの削除が正常に完了しました"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "このサーバーでは CIRA が無効になっています。このプロファイルは管理接続に CIRA を使用しているため、CIRA が再度有効になるまで機能しません。"
   },
   "profiles.exportProfile": {
     "description": "エクスポートされたプロファイルに関するメッセージ",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -2145,6 +2145,14 @@
     "description": "Label voor CIRA-configuratieveld",
     "value": "CIRA-configuratie"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA is uitgeschakeld op deze server)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA is uitgeschakeld op deze server. Dit profiel gebruikt CIRA voor zijn beheerverbinding en werkt pas als CIRA opnieuw is ingeschakeld."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Label voor het gedeelte over verbindingsconfiguratie",
     "value": "Configuratie van de geleverde verbinding"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Bericht voor verwijderde profielen",
     "value": "Profiel succesvol verwijderd."
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA is uitgeschakeld op deze server. Dit profiel gebruikt CIRA voor zijn beheerverbinding en werkt pas als CIRA opnieuw is ingeschakeld."
   },
   "profiles.exportProfile": {
     "description": "Bericht voor geëxporteerde profielen",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2145,6 +2145,14 @@
     "description": "Метка для поля конфигурации CIRA",
     "value": "Конфигурация CIRA"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA отключён на этом сервере)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA отключён на этом сервере. Этот профиль использует CIRA для подключения управления и не будет работать, пока CIRA не будет снова включён."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Метка для раздела настройки подключения",
     "value": "Настройка предоставленного соединения"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Сообщение об удаленных профилях",
     "value": "Профиль удален успешно"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA отключён на этом сервере. Этот профиль использует CIRA для подключения управления и не будет работать, пока CIRA не будет снова включён."
   },
   "profiles.exportProfile": {
     "description": "Сообщение для экспортированных профилей",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2145,6 +2145,14 @@
     "description": "Etikett för CIRA-konfigurationsfält",
     "value": "CIRA-konfiguration"
   },
+  "profileDetail.ciraDisabledOption": {
+    "description": "Inline note on the CIRA radio when CIRA is disabled on the server",
+    "value": "(CIRA är inaktiverat på den här servern)"
+  },
+  "profileDetail.ciraDisabledWarning": {
+    "description": "Warning shown when editing a profile that uses CIRA while CIRA is disabled on the server",
+    "value": "CIRA är inaktiverat på den här servern. Den här profilen använder CIRA för sin hanteringsanslutning och fungerar inte förrän CIRA återaktiveras."
+  },
   "profileDetail.connectionConfiguration": {
     "description": "Etikett för avsnittet om anslutningskonfiguration",
     "value": "Konfiguration av tillhandahållen anslutning"
@@ -2332,6 +2340,10 @@
   "profiles.deleteProfile": {
     "description": "Meddelande för raderade profiler",
     "value": "Profilen har raderats"
+  },
+  "profiles.ciraExportDisabled": {
+    "description": "Shown when exporting a CIRA profile while CIRA is disabled on the server",
+    "value": "CIRA är inaktiverat på den här servern. Den här profilen använder CIRA för sin hanteringsanslutning och fungerar inte förrän CIRA återaktiveras."
   },
   "profiles.exportProfile": {
     "description": "Meddelande för exporterade profiler",

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -538,3 +538,8 @@ export interface DisplaySelectionResponse {
 export interface DisplaySelectionRequest {
   displayIndex: number
 }
+
+// Server-level capability flags exposed by the Console API (enterprise build).
+export interface ServerFeatures {
+  ciraEnabled: boolean
+}


### PR DESCRIPTION
In the enterprise build, fetch GET /api/v1/server/features from the Console API on navbar init and show the CIRA tab only when ciraEnabled is true (driven by the server's APP_DISABLE_CIRA setting). The cloud (MPS+RPS) build is unchanged and continues to show the tab.

Adds ServerFeaturesService and the ServerFeatures model, with specs for the service and the navbar's cloud/enterprise branches.

Resolves #3200

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
