### PR TITLE
feat(devices): add network settings management for AMT devices

### DIFF
--- a/src/app/devices/devices.service.spec.ts
+++ b/src/app/devices/devices.service.spec.ts
@@ -16,7 +16,9 @@ import {
   IPSAlarmClockOccurrence,
   IPSAlarmClockOccurrenceInput,
   BootDetails,
-  DisplaySelectionResponse
+  DisplaySelectionResponse,
+  WirelessProfileSyncResponse,
+  WirelessProfileSyncRequest
 } from '../../models/models'
 import { provideTranslateService } from '@ngx-translate/core'
 
@@ -1122,6 +1124,175 @@ describe('DevicesService', () => {
 
       const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/tls/guid1`)
       req.flush(null, mockError)
+    })
+  })
+
+  describe('getWiredNetworkSettings', () => {
+    it('should fetch wired network settings for a device', () => {
+      const mockResponse = { dhcpEnabled: true } as any
+
+      service.getWiredNetworkSettings('guid1').subscribe((response) => {
+        expect(response).toEqual(mockResponse)
+      })
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wired/guid1`)
+      expect(req.request.method).toBe('GET')
+      req.flush(mockResponse)
+    })
+  })
+
+  describe('patchWiredNetworkSettings', () => {
+    it('should patch wired network settings for a device', () => {
+      const payload = {
+        dhcpEnabled: false,
+        ipSyncEnabled: false,
+        ipAddress: '192.168.1.20',
+        subnetMask: '255.255.255.0',
+        defaultGateway: '192.168.1.1',
+        primaryDNS: '8.8.8.8'
+      }
+
+      service.patchWiredNetworkSettings('guid1', payload).subscribe()
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wired/guid1`)
+      expect(req.request.method).toBe('PATCH')
+      expect(req.request.body).toEqual(payload)
+      req.flush(null)
+    })
+  })
+
+  describe('wireless network configuration endpoints', () => {
+    it('should get wireless state', () => {
+      const mockResponse = { state: 'WifiEnabledS0SxAC' }
+
+      service.getWirelessState('guid1').subscribe((response) => {
+        expect(response).toEqual(mockResponse as any)
+      })
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/state/guid1`)
+      expect(req.request.method).toBe('GET')
+      req.flush(mockResponse)
+    })
+
+    it('should request wireless state change', () => {
+      const payload = { state: 'WifiDisabled' }
+
+      service.requestWirelessStateChange('guid1', payload as any).subscribe((response) => {
+        expect(response).toEqual(payload as any)
+      })
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/state/guid1`)
+      expect(req.request.method).toBe('POST')
+      expect(req.request.body).toEqual(payload)
+      req.flush(payload)
+    })
+
+    it('should get profile sync setting', () => {
+      const mockResponse: WirelessProfileSyncResponse = {
+        localProfileSync: true,
+        uefiProfileSync: false,
+        uefiProfileSyncSupported: true
+      }
+
+      service.getWirelessProfileSync('guid1').subscribe((response) => {
+        expect(response).toEqual(mockResponse)
+      })
+
+      const req = httpMock.expectOne(
+        `${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/profileSync/guid1`
+      )
+      expect(req.request.method).toBe('GET')
+      req.flush(mockResponse)
+    })
+
+    it('should update profile sync setting', () => {
+      const payload: WirelessProfileSyncRequest = {
+        localProfileSync: true,
+        uefiProfileSync: false
+      }
+
+      const mockResponse: WirelessProfileSyncResponse = {
+        localProfileSync: true,
+        uefiProfileSync: false,
+        uefiProfileSyncSupported: true
+      }
+
+      service.setWirelessProfileSync('guid1', payload).subscribe((response) => {
+        expect(response).toEqual(mockResponse)
+      })
+
+      const req = httpMock.expectOne(
+        `${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/profileSync/guid1`
+      )
+      expect(req.request.method).toBe('POST')
+      expect(req.request.body).toEqual(payload)
+      req.flush(mockResponse)
+    })
+
+    it('should get wireless profiles', () => {
+      const mockResponse = [
+        {
+          profileName: 'office',
+          ssid: 'CorpNet',
+          authenticationMethod: 'WPA2PSK',
+          encryptionMethod: 'CCMP',
+          priority: 1
+        }
+      ]
+
+      service.getWirelessProfiles('guid1').subscribe((response) => {
+        expect(response).toEqual(mockResponse as any)
+      })
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/guid1`)
+      expect(req.request.method).toBe('GET')
+      req.flush(mockResponse)
+    })
+
+    it('should add wireless profile', () => {
+      const payload = {
+        profileName: 'office',
+        ssid: 'CorpNet',
+        authenticationMethod: 'WPA2PSK',
+        encryptionMethod: 'CCMP',
+        priority: 1,
+        password: 'password123'
+      }
+
+      service.addWirelessProfile('guid1', payload).subscribe()
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/guid1`)
+      expect(req.request.method).toBe('POST')
+      expect(req.request.body).toEqual(payload)
+      req.flush(null)
+    })
+
+    it('should update wireless profile', () => {
+      const payload = {
+        profileName: 'office',
+        ssid: 'CorpNet-2',
+        authenticationMethod: 'WPA2PSK',
+        encryptionMethod: 'CCMP',
+        priority: 2,
+        password: 'password123'
+      }
+
+      service.updateWirelessProfile('guid1', payload).subscribe()
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/guid1`)
+      expect(req.request.method).toBe('PATCH')
+      expect(req.request.body).toEqual(payload)
+      req.flush(null)
+    })
+
+    it('should delete wireless profile', () => {
+      service.deleteWirelessProfile('guid1', 'office profile').subscribe()
+
+      const req = httpMock.expectOne(
+        `${mockEnvironment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/guid1/${encodeURIComponent('office profile')}`
+      )
+      expect(req.request.method).toBe('DELETE')
+      req.flush(null)
     })
   })
 

--- a/src/app/devices/devices.service.ts
+++ b/src/app/devices/devices.service.ts
@@ -26,6 +26,14 @@ import {
   IPSAlarmClockOccurrence,
   Certificates,
   NetworkConfig,
+  WiredNetworkSettings,
+  WiredNetworkConfigRequest,
+  WirelessStateResponse,
+  WirelessStateChangeRequest,
+  WirelessProfileSyncRequest,
+  WirelessProfileSyncResponse,
+  DeviceWirelessProfileRequest,
+  DeviceWirelessProfileResponse,
   TLSSettings,
   CertInfo,
   BootDetails,
@@ -589,6 +597,117 @@ export class DevicesService {
       })
     )
   }
+
+  getWiredNetworkSettings(guid: string): Observable<WiredNetworkSettings> {
+    return this.http
+      .get<WiredNetworkSettings>(`${environment.mpsServer}/api/v1/amt/networkSettings/wired/${guid}`)
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  patchWiredNetworkSettings(guid: string, payload: WiredNetworkConfigRequest): Observable<void> {
+    return this.http.patch<void>(`${environment.mpsServer}/api/v1/amt/networkSettings/wired/${guid}`, payload).pipe(
+      catchError((err) => {
+        throw err
+      })
+    )
+  }
+
+  getWirelessState(guid: string): Observable<WirelessStateResponse> {
+    return this.http
+      .get<WirelessStateResponse>(`${environment.mpsServer}/api/v1/amt/networkSettings/wireless/state/${guid}`)
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  requestWirelessStateChange(guid: string, payload: WirelessStateChangeRequest): Observable<WirelessStateResponse> {
+    return this.http
+      .post<WirelessStateResponse>(
+        `${environment.mpsServer}/api/v1/amt/networkSettings/wireless/state/${guid}`,
+        payload
+      )
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  getWirelessProfileSync(guid: string): Observable<WirelessProfileSyncResponse> {
+    return this.http
+      .get<WirelessProfileSyncResponse>(
+        `${environment.mpsServer}/api/v1/amt/networkSettings/wireless/profileSync/${guid}`
+      )
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  setWirelessProfileSync(guid: string, payload: WirelessProfileSyncRequest): Observable<WirelessProfileSyncResponse> {
+    return this.http
+      .post<WirelessProfileSyncResponse>(
+        `${environment.mpsServer}/api/v1/amt/networkSettings/wireless/profileSync/${guid}`,
+        payload
+      )
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  getWirelessProfiles(guid: string): Observable<DeviceWirelessProfileResponse[]> {
+    return this.http
+      .get<
+        DeviceWirelessProfileResponse[]
+      >(`${environment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/${guid}`)
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  addWirelessProfile(guid: string, payload: DeviceWirelessProfileRequest): Observable<void> {
+    return this.http
+      .post<void>(`${environment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/${guid}`, payload)
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  updateWirelessProfile(guid: string, payload: DeviceWirelessProfileRequest): Observable<void> {
+    return this.http
+      .patch<void>(`${environment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/${guid}`, payload)
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
+  deleteWirelessProfile(guid: string, profileName: string): Observable<void> {
+    return this.http
+      .delete<void>(
+        `${environment.mpsServer}/api/v1/amt/networkSettings/wireless/profile/${guid}/${encodeURIComponent(profileName)}`
+      )
+      .pipe(
+        catchError((err) => {
+          throw err
+        })
+      )
+  }
+
   getTLSSettings(guid: string): Observable<TLSSettings[]> {
     return this.http.get<any>(`${environment.mpsServer}/api/v1/amt/tls/${guid}`).pipe(
       catchError((err) => {

--- a/src/app/devices/network-settings/network-settings.component.html
+++ b/src/app/devices/network-settings/network-settings.component.html
@@ -1,424 +1,747 @@
-@if (isLoading()) {
-  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-}
-<div class="flex-1 flex-row">
-  @if (networkResults?.wired != null) {
-    <mat-card class="flex flex-50 gap-12">
-      <mat-card-header>
-        <mat-card-title>{{ 'network.wired.title.value' | translate }}</mat-card-title>
-        <mat-card-subtitle>{{ 'network.wired.subtitle.value' | translate }}</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="flex-row flex-wrap">
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.ipAddress.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.ipAddress || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.subnetMask.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.subnetMask || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.defaultGateway.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.defaultGateway || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.primaryDNS.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.primaryDNS || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.secondaryDNS.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.secondaryDNS || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.ipSyncEnabled.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wired?.ipSyncEnabled ? ('common.yes.value' | translate) : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.dhcpEnabled.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wired?.dhcpEnabled ? ('common.yes.value' | translate) : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.sharedMAC.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wired?.sharedMAC ? ('common.yes.value' | translate) : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.macAddress.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.macAddress || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.linkStatus.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wired?.linkIsUp ? ('common.yes.value' | translate) : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.linkPolicy.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.linkPolicy || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.linkPreference.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.linkPreference || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.linkControl.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.linkControl || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.sharedStaticIP.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wired?.sharedStaticIP ? ('common.yes.value' | translate) : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wired.sharedDynamicIP.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wired?.sharedDynamicIP
-                ? ('common.yes.value' | translate)
-                : ('common.no.value' | translate)
-            }}</span>
-          </div>
-        </div>
-      </mat-card-content>
-    </mat-card>
-  }
-
-  @if (networkResults?.wireless != null) {
-    <mat-card class="flex flex-50 gap-12">
-      <mat-card-header>
-        <mat-card-title>{{ 'network.wireless.title.value' | translate }}</mat-card-title>
-        <mat-card-subtitle>{{ 'network.wireless.subtitle.value' | translate }}</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="flex-row flex-wrap">
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.ipAddress.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.ipAddress || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.subnetMask.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.subnetMask || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.defaultGateway.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.defaultGateway || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.primaryDNS.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.primaryDNS || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.secondaryDNS.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.secondaryDNS || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.ipSyncEnabled.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wireless?.ipSyncEnabled
-                ? ('common.yes.value' | translate)
-                : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.dhcpEnabled.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wireless?.dhcpEnabled ? ('common.yes.value' | translate) : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.sharedMAC.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wireless?.sharedMAC ? ('common.yes.value' | translate) : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.macAddress.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.macAddress || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.linkStatus.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wireless?.linkIsUp ? ('common.up.value' | translate) : ('common.down.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.linkPolicy.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.linkPolicy || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.linkPreference.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.linkPreference || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.linkControl.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wireless?.linkControl || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.sharedStaticIP.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wireless?.sharedStaticIP
-                ? ('common.yes.value' | translate)
-                : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.sharedDynamicIP.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wireless?.sharedDynamicIP
-                ? ('common.yes.value' | translate)
-                : ('common.no.value' | translate)
-            }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.wireless.localProfileSync.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{
-              networkResults?.wireless?.wifiPortConfigService?.localProfileSynchronizationEnabled === 1
-                ? ('common.enabled.value' | translate)
-                : ('common.disabled.value' | translate)
-            }}</span>
-          </div>
-        </div>
-      </mat-card-content>
-    </mat-card>
-  }
-</div>
-
-<div class="flex-1 flex-row">
-  <mat-card class="flex flex-50 gap-12">
-    <mat-card-header>
-      <mat-card-title>{{ 'network.ieee.title.value' | translate }}</mat-card-title>
-      <mat-card-subtitle>{{ 'network.ieee.subtitle.value' | translate }}</mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      @if (networkResults?.wired != null) {
-        <div class="flex-row flex-wrap">
-          <div class="flex flex-50">
-            <p>{{ 'network.ieee.availableInS0.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.ieee8021x?.availableInS0 || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.ieee.enabled.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.ieee8021x?.enabled || 'N/A' }}</span>
-          </div>
-
-          <div class="flex flex-50">
-            <p>{{ 'network.ieee.pxeTimeout.value' | translate }}</p>
-          </div>
-          <div class="flex flex-50 justify-end">
-            <span class="mat-h3">{{ networkResults?.wired?.ieee8021x?.pxeTimeout || 'N/A' }}</span>
-          </div>
-        </div>
-      }
-
-      @if (networkResults?.wireless != null) {
-        <mat-divider style="padding-bottom: 16px"></mat-divider>
-        @for (setting of networkResults?.wireless?.ieee8021xSettings; track $index) {
-          <div class="flex-row flex-wrap">
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.authProtocol.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.authenticationProtocol }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.roamingIdentity.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.roamingIdentity || 'N/A' }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.serverCertName.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.serverCertificateName || 'N/A' }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.serverCertComparison.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.serverCertificateNameComparison }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.username.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.username }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.password.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.password || 'N/A' }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.domain.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.domain || 'N/A' }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.pac.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.protectedAccessCredential || 'N/A' }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.pacPassword.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.pacPassword || 'N/A' }}</span>
-            </div>
-
-            <div class="flex flex-50">
-              <p>{{ 'network.ieee.psk.value' | translate }}</p>
-            </div>
-            <div class="flex flex-50 justify-end">
-              <span class="mat-h3">{{ setting.psk || 'N/A' }}</span>
-            </div>
-          </div>
-        }
-      }
-    </mat-card-content>
-  </mat-card>
-
-  @if (networkResults?.wireless != null) {
-    <mat-card class="flex flex-50 gap-12">
-      <mat-card-header>
-        <mat-card-title>{{ 'network.wirelessNetworks.title.value' | translate }}</mat-card-title>
-        <mat-card-subtitle>{{ 'network.wirelessNetworks.subtitle.value' | translate }}</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <mat-list>
-          @for (network of networkResults?.wireless?.wifiNetworks; track $index) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>wifi</mat-icon>
-              <span matListItemTitle>{{
-                'network.wirelessNetworks.name.value' | translate: { name: network.elementName }
-              }}</span>
-              <span matListItemLine>{{
-                'network.wirelessNetworks.ssid.value' | translate: { ssid: network.ssid }
-              }}</span>
-              <span matListItemLine>
-                {{
-                  'network.wirelessNetworks.encryption.value' | translate: { encryptMethod: network.encryptionMethod }
-                }}
-                |
-                {{ 'network.wirelessNetworks.auth.value' | translate: { authMethod: network.authenticationMethod } }}
-              </span>
-            </mat-list-item>
+<mat-tab-group
+  class="network-tabs"
+  animationDuration="0ms"
+  [selectedIndex]="selectedTabIndex()"
+  (selectedIndexChange)="selectedTabIndex.set($event)">
+  <mat-tab [disabled]="!hasWiredAdapter()">
+    <ng-template mat-tab-label>
+      <mat-icon class="network-tab-icon">settings_ethernet</mat-icon>
+      {{ 'common.wired.value' | translate }}
+    </ng-template>
+    <div class="network-tab-content">
+      @if (isWiredLoading() || networkResults()?.wired != null) {
+        <mat-card class="flex flex-1 gap-12">
+          @if (isWiredLoading() || isSavingWired() || isRefreshingNetwork()) {
+            <mat-progress-bar mode="indeterminate"></mat-progress-bar>
           }
-        </mat-list>
-      </mat-card-content>
-    </mat-card>
-  }
-</div>
+          @if (!isWiredLoading()) {
+            <button
+              class="card-edit-button"
+              mat-button
+              color="primary"
+              type="button"
+              [attr.aria-label]="'common.editSettings.value' | translate"
+              (click)="toggleWiredConfigForm()">
+              <mat-icon>{{ showWiredConfigForm() ? 'close' : 'edit' }}</mat-icon>
+              {{ 'common.editSettings.value' | translate }}
+            </button>
+          }
+          <mat-card-header>
+            <mat-card-title>{{ 'network.wired.title.value' | translate }}</mat-card-title>
+            <mat-card-subtitle>{{ 'network.wired.subtitle.value' | translate }}</mat-card-subtitle>
+          </mat-card-header>
+          @if (!isWiredLoading()) {
+            <mat-card-content>
+              @if (showWiredConfigForm()) {
+                <div class="network-config-section">
+                  <form class="network-form" [formGroup]="wiredForm" (ngSubmit)="saveWiredSettings()">
+                    <mat-radio-group class="flex flex-1" name="dhcpEnabled" formControlName="dhcpEnabled">
+                      <mat-radio-button [value]="true">{{ 'profileDetail.dhcp.value' | translate }}</mat-radio-button>
+                      <mat-radio-button [value]="false">{{
+                        'profileDetail.static.value' | translate
+                      }}</mat-radio-button>
+                    </mat-radio-group>
+
+                    <mat-checkbox class="flex flex-1" formControlName="ipSyncEnabled">
+                      {{ 'profileDetail.enableIpSynchronization.value' | translate }}
+                      @if (wiredForm.controls.ipSyncEnabled.enabled) {
+                        <p class="like-mat-hint">{{ 'network.wired.ipSyncHintEnabled.value' | translate }}</p>
+                      }
+                      @if (wiredForm.controls.ipSyncEnabled.disabled) {
+                        <p class="like-mat-hint">{{ 'profileDetail.ipSyncHintDisabled.value' | translate }}</p>
+                      }
+                    </mat-checkbox>
+
+                    @if (!wiredForm.controls.dhcpEnabled.value && !wiredForm.controls.ipSyncEnabled.value) {
+                      <div class="network-form-grid">
+                        <mat-form-field appearance="fill">
+                          <mat-label>{{ 'network.wired.ipAddress.value' | translate }}</mat-label>
+                          <input matInput formControlName="ipAddress" />
+                        </mat-form-field>
+
+                        <mat-form-field appearance="fill">
+                          <mat-label>{{ 'network.wired.subnetMask.value' | translate }}</mat-label>
+                          <input matInput formControlName="subnetMask" />
+                        </mat-form-field>
+
+                        <mat-form-field appearance="fill">
+                          <mat-label>{{ 'network.wired.defaultGateway.value' | translate }}</mat-label>
+                          <input matInput formControlName="defaultGateway" />
+                        </mat-form-field>
+
+                        <mat-form-field appearance="fill">
+                          <mat-label>{{ 'network.wired.primaryDNS.value' | translate }}</mat-label>
+                          <input matInput formControlName="primaryDNS" />
+                        </mat-form-field>
+
+                        <mat-form-field appearance="fill">
+                          <mat-label>{{ 'network.wired.secondaryDNS.value' | translate }}</mat-label>
+                          <input matInput formControlName="secondaryDNS" />
+                        </mat-form-field>
+                      </div>
+                    }
+
+                    <div class="network-form-actions">
+                      <button mat-button type="button" (click)="cancelWiredSettings()">
+                        {{ 'common.cancelLower.value' | translate }}
+                      </button>
+                      <button
+                        mat-flat-button
+                        color="primary"
+                        type="submit"
+                        [disabled]="isSavingWired() || wiredForm.pristine">
+                        {{ 'common.save.value' | translate }}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              }
+              <div class="flex-row flex-wrap">
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.linkStatus.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span
+                    class="mat-h3"
+                    [class.status-up]="networkResults()?.wired?.linkIsUp"
+                    [class.status-down]="!networkResults()?.wired?.linkIsUp">
+                    {{
+                      networkResults()?.wired?.linkIsUp
+                        ? ('common.up.value' | translate)
+                        : ('common.down.value' | translate)
+                    }}
+                  </span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.dhcpEnabled.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{
+                    networkResults()?.wired?.dhcpEnabled
+                      ? ('common.yes.value' | translate)
+                      : ('common.no.value' | translate)
+                  }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.sharedIP.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{
+                    networkResults()?.wired?.ipSyncEnabled
+                      ? networkResults()?.wired?.dhcpEnabled
+                        ? ('network.sharedIP.dynamic.value' | translate)
+                        : ('network.sharedIP.static.value' | translate)
+                      : ('network.sharedIP.none.value' | translate)
+                  }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.macAddress.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wired?.macAddress || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.ipAddress.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wired?.ipAddress || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.subnetMask.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wired?.subnetMask || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.defaultGateway.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wired?.defaultGateway || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.primaryDNS.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wired?.primaryDNS || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wired.secondaryDNS.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wired?.secondaryDNS || 'N/A' }}</span>
+                </div>
+
+                <button
+                  type="button"
+                  class="flex flex-50 ieee-status-label"
+                  [attr.aria-expanded]="wiredIeee8021xExpanded()"
+                  (click)="toggleWiredIeee8021x()">
+                  <mat-icon class="ieee-expand-icon">{{
+                    wiredIeee8021xExpanded() ? 'expand_more' : 'chevron_right'
+                  }}</mat-icon>
+                  <span class="ieee-status-text">{{ 'network.ieee.status.value' | translate }}</span>
+                </button>
+                <div class="flex flex-50 justify-end">
+                  <span
+                    class="mat-h3"
+                    [class.status-up]="isWiredIeee8021xEnabled()"
+                    [class.status-down]="!isWiredIeee8021xEnabled()">
+                    {{ (isWiredIeee8021xEnabled() ? 'network.enabled.value' : 'network.disabled.value') | translate }}
+                  </span>
+                </div>
+
+                @if (wiredIeee8021xExpanded()) {
+                  <div class="flex flex-50 ieee-sub-item">
+                    <p>{{ 'network.ieee.availableInS0.value' | translate }}</p>
+                  </div>
+                  <div class="flex flex-50 justify-end">
+                    <span class="mat-h3">{{
+                      networkResults()?.wired?.ieee8021x?.availableInS0
+                        ? ('common.yes.value' | translate)
+                        : ('common.no.value' | translate)
+                    }}</span>
+                  </div>
+
+                  <div class="flex flex-50 ieee-sub-item">
+                    <p>{{ 'network.ieee.pxeTimeout.value' | translate }}</p>
+                  </div>
+                  <div class="flex flex-50 justify-end">
+                    <span class="mat-h3">{{ networkResults()?.wired?.ieee8021x?.pxeTimeout ?? 'N/A' }}</span>
+                  </div>
+                }
+              </div>
+            </mat-card-content>
+          }
+        </mat-card>
+      }
+    </div>
+  </mat-tab>
+
+  <mat-tab [disabled]="!hasWirelessAdapter()">
+    <ng-template mat-tab-label>
+      <mat-icon class="network-tab-icon">wifi</mat-icon>
+      {{ 'common.wireless.value' | translate }}
+    </ng-template>
+    <div class="network-tab-content">
+      @if (isWirelessLoading() || networkResults()?.wireless != null) {
+        <mat-card class="flex flex-1 gap-12">
+          @if (
+            isWirelessLoading() ||
+            isWirelessConfigLoading() ||
+            isSavingWireless() ||
+            isSavingWirelessProfile() ||
+            isRefreshingNetwork()
+          ) {
+            <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+          }
+          @if (!isWirelessLoading() && !isWirelessConfigLoading()) {
+            <button
+              class="card-edit-button"
+              mat-button
+              color="primary"
+              type="button"
+              [attr.aria-label]="'common.editSettings.value' | translate"
+              (click)="toggleWirelessConfigForm()">
+              <mat-icon>{{ showWirelessConfigForm() ? 'close' : 'edit' }}</mat-icon>
+              {{ 'common.editSettings.value' | translate }}
+            </button>
+          }
+          <mat-card-header>
+            <mat-card-title>{{ 'network.wireless.title.value' | translate }}</mat-card-title>
+            <mat-card-subtitle>{{ 'network.wireless.subtitle.value' | translate }}</mat-card-subtitle>
+          </mat-card-header>
+          @if (!isWirelessLoading() && !isWirelessConfigLoading()) {
+            <mat-card-content>
+              @if (showWirelessConfigForm()) {
+                <div class="network-config-section">
+                  <form class="network-form" [formGroup]="wirelessSettingsForm" (ngSubmit)="saveWirelessSettings()">
+                    <mat-slide-toggle color="primary" formControlName="enabled">
+                      {{
+                        (wirelessSettingsForm.controls.enabled.value
+                          ? 'network.wireless.wifiEnabled.value'
+                          : 'network.wireless.wifiDisabled.value'
+                        ) | translate
+                      }}
+                    </mat-slide-toggle>
+
+                    <mat-checkbox class="flex flex-1" formControlName="localProfileSyncEnabled">
+                      {{ 'network.wireless.localProfileSyncToggle.value' | translate }}
+                    </mat-checkbox>
+
+                    <mat-checkbox class="flex flex-1" formControlName="uefiProfileSyncEnabled">
+                      {{ 'network.wireless.uefiProfileSyncToggle.value' | translate }}
+                    </mat-checkbox>
+                    @if (!uefiProfileSyncSupported()) {
+                      <p class="like-mat-hint">{{ 'network.wireless.uefiProfileSyncUnsupported.value' | translate }}</p>
+                    }
+
+                    <div class="network-form-actions">
+                      <button mat-button type="button" (click)="cancelWirelessSettings()">
+                        {{ 'common.cancelLower.value' | translate }}
+                      </button>
+                      <button
+                        mat-flat-button
+                        color="primary"
+                        type="submit"
+                        [disabled]="isSavingWireless() || wirelessSettingsForm.pristine">
+                        {{ 'common.save.value' | translate }}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              }
+              <div class="flex-row flex-wrap">
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.state.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span
+                    class="mat-h3"
+                    [class.status-up]="wirelessStatus()?.enabled"
+                    [class.status-down]="!wirelessStatus()?.enabled">
+                    {{ (wirelessStatus()?.enabled ? 'network.enabled.value' : 'network.disabled.value') | translate }}
+                  </span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.localProfileSync.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span
+                    class="mat-h3"
+                    [class.status-up]="wirelessStatus()?.localProfileSyncEnabled"
+                    [class.status-down]="!wirelessStatus()?.localProfileSyncEnabled">
+                    {{
+                      (wirelessStatus()?.localProfileSyncEnabled ? 'network.enabled.value' : 'network.disabled.value')
+                        | translate
+                    }}
+                  </span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.uefiProfileSync.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span
+                    class="mat-h3"
+                    [class.status-up]="wirelessStatus()?.uefiProfileSyncEnabled"
+                    [class.status-down]="!wirelessStatus()?.uefiProfileSyncEnabled">
+                    {{
+                      (wirelessStatus()?.uefiProfileSyncEnabled ? 'network.enabled.value' : 'network.disabled.value')
+                        | translate
+                    }}
+                  </span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.linkStatus.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span
+                    class="mat-h3"
+                    [class.status-up]="networkResults()?.wireless?.linkIsUp"
+                    [class.status-down]="!networkResults()?.wireless?.linkIsUp">
+                    {{
+                      networkResults()?.wireless?.linkIsUp
+                        ? ('common.up.value' | translate)
+                        : ('common.down.value' | translate)
+                    }}
+                  </span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.dhcpEnabled.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{
+                    networkResults()?.wireless?.dhcpEnabled
+                      ? ('common.yes.value' | translate)
+                      : ('common.no.value' | translate)
+                  }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.sharedIP.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{
+                    networkResults()?.wireless?.ipSyncEnabled
+                      ? networkResults()?.wireless?.dhcpEnabled
+                        ? ('network.sharedIP.dynamic.value' | translate)
+                        : ('network.sharedIP.static.value' | translate)
+                      : ('network.sharedIP.none.value' | translate)
+                  }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.macAddress.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wireless?.macAddress || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.ipAddress.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wireless?.ipAddress || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.subnetMask.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wireless?.subnetMask || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.defaultGateway.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wireless?.defaultGateway || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.primaryDNS.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wireless?.primaryDNS || 'N/A' }}</span>
+                </div>
+
+                <div class="flex flex-50">
+                  <p>{{ 'network.wireless.secondaryDNS.value' | translate }}</p>
+                </div>
+                <div class="flex flex-50 justify-end">
+                  <span class="mat-h3">{{ networkResults()?.wireless?.secondaryDNS || 'N/A' }}</span>
+                </div>
+              </div>
+            </mat-card-content>
+          }
+        </mat-card>
+
+        <mat-card class="flex flex-1 gap-12 wireless-profile-card">
+          @if (isWirelessConfigLoading() || isSavingWirelessProfile() || isLoadingWirelessProfiles()) {
+            <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+          }
+          @if (!isWirelessConfigLoading()) {
+            <button
+              class="profile-add-button"
+              mat-button
+              color="primary"
+              type="button"
+              [disabled]="isWirelessProfileLimitReached()"
+              [matTooltip]="
+                isWirelessProfileLimitReached()
+                  ? ('network.wirelessProfile.limitReached.value' | translate: { max: maxWirelessProfiles })
+                  : ''
+              "
+              [matTooltipDisabled]="!isWirelessProfileLimitReached()"
+              (click)="toggleWirelessProfileForm()">
+              <mat-icon>{{
+                showWirelessProfileForm() && editingWirelessProfileName() == null ? 'close' : 'add'
+              }}</mat-icon>
+              {{ 'network.wirelessProfile.addNew.value' | translate }}
+            </button>
+          }
+          <mat-card-header>
+            <mat-card-title>{{ 'network.wirelessProfile.manageTitle.value' | translate }}</mat-card-title>
+            <mat-card-subtitle>{{ 'network.wirelessProfile.manageSubtitle.value' | translate }}</mat-card-subtitle>
+          </mat-card-header>
+          @if (!isWirelessConfigLoading()) {
+            <mat-card-content>
+              @if (showWirelessProfileForm()) {
+                <form class="network-form" [formGroup]="wirelessProfileForm" (ngSubmit)="saveWirelessProfile()">
+                  <div class="network-form-title">
+                    {{
+                      editingWirelessProfileName() == null
+                        ? ('network.wirelessProfile.addTitle.value' | translate)
+                        : ('network.wirelessProfile.editTitle.value' | translate)
+                    }}
+                  </div>
+
+                  <div class="network-form-grid">
+                    <mat-form-field appearance="fill">
+                      <mat-label>{{ 'network.wirelessProfile.profileName.value' | translate }}</mat-label>
+                      <input matInput formControlName="profileName" />
+                      @if (wirelessProfileForm.controls.profileName.hasError('required')) {
+                        <mat-error>{{ 'network.wirelessProfile.profileNameRequired.value' | translate }}</mat-error>
+                      } @else if (wirelessProfileForm.controls.profileName.hasError('pattern')) {
+                        <mat-error>{{ 'network.wirelessProfile.profileNamePattern.value' | translate }}</mat-error>
+                      }
+                    </mat-form-field>
+
+                    <mat-form-field appearance="fill">
+                      <mat-label>{{ 'network.wirelessProfile.ssid.value' | translate }}</mat-label>
+                      <input matInput formControlName="ssid" />
+                      @if (wirelessProfileForm.controls.ssid.hasError('required')) {
+                        <mat-error>{{ 'network.wirelessProfile.ssidRequired.value' | translate }}</mat-error>
+                      }
+                    </mat-form-field>
+
+                    <mat-form-field appearance="fill">
+                      <mat-label>{{ 'network.wirelessProfile.priority.value' | translate }}</mat-label>
+                      <input
+                        matInput
+                        type="number"
+                        formControlName="priority"
+                        min="1"
+                        max="255"
+                        (keydown)="blockNonNumericKey($event)" />
+                      @if (wirelessProfileForm.controls.priority.hasError('required')) {
+                        <mat-error>{{ 'network.wirelessProfile.priorityRequired.value' | translate }}</mat-error>
+                      } @else if (wirelessProfileForm.controls.priority.hasError('priorityConflict')) {
+                        <mat-error>{{ 'network.wirelessProfile.priorityConflict.value' | translate }}</mat-error>
+                      } @else if (wirelessProfileForm.controls.priority.invalid) {
+                        <mat-error>{{ 'network.wirelessProfile.priorityRange.value' | translate }}</mat-error>
+                      }
+                    </mat-form-field>
+
+                    <mat-form-field appearance="fill">
+                      <mat-label>{{ 'network.wirelessProfile.authMethod.value' | translate }}</mat-label>
+                      <mat-select formControlName="authenticationMethod">
+                        @for (method of wirelessAuthMethodOptions; track method) {
+                          <mat-option [value]="method">{{ method }}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+
+                    <mat-form-field appearance="fill">
+                      <mat-label>{{ 'network.wirelessProfile.encryptionMethod.value' | translate }}</mat-label>
+                      <mat-select formControlName="encryptionMethod">
+                        @for (method of wirelessEncryptionMethodOptions; track method) {
+                          <mat-option [value]="method">{{ method }}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+
+                    @if (
+                      wirelessProfileForm.controls.authenticationMethod.value === 'WPAPSK' ||
+                      wirelessProfileForm.controls.authenticationMethod.value === 'WPA2PSK'
+                    ) {
+                      <mat-form-field appearance="fill">
+                        <mat-label>{{ 'network.wirelessProfile.password.value' | translate }}</mat-label>
+                        <input matInput formControlName="password" type="password" />
+                        @if (wirelessProfileForm.controls.password.invalid) {
+                          <mat-error>{{ 'network.wirelessProfile.passwordRequired.value' | translate }}</mat-error>
+                        }
+                      </mat-form-field>
+                    } @else {
+                      <mat-form-field appearance="fill">
+                        <mat-label>{{ 'network.wirelessProfile.ieee8021xUsername.value' | translate }}</mat-label>
+                        <input matInput formControlName="ieee8021xUsername" />
+                        @if (wirelessProfileForm.controls.ieee8021xUsername.invalid) {
+                          <mat-error>{{ 'network.wirelessProfile.usernameRequired.value' | translate }}</mat-error>
+                        }
+                      </mat-form-field>
+
+                      <mat-form-field appearance="fill">
+                        <mat-label>{{ 'network.wirelessProfile.ieee8021xProtocol.value' | translate }}</mat-label>
+                        <mat-select formControlName="ieee8021xAuthenticationProtocol">
+                          @for (method of wirelessIEEE8021xProtocolOptions; track method.value) {
+                            <mat-option [value]="method.value">{{ method.label }}</mat-option>
+                          }
+                        </mat-select>
+                      </mat-form-field>
+
+                      @if (
+                        wirelessProfileForm.controls.ieee8021xAuthenticationProtocol.value === ieee8021xProtocolPEAP
+                      ) {
+                        <mat-form-field appearance="fill">
+                          <mat-label>{{ 'network.wirelessProfile.ieee8021xPassword.value' | translate }}</mat-label>
+                          <input matInput formControlName="ieee8021xPassword" type="password" />
+                          @if (wirelessProfileForm.controls.ieee8021xPassword.invalid) {
+                            <mat-error>{{
+                              'network.wirelessProfile.ieee8021xPasswordRequired.value' | translate
+                            }}</mat-error>
+                          }
+                        </mat-form-field>
+                      }
+
+                      @if (
+                        wirelessProfileForm.controls.ieee8021xAuthenticationProtocol.value === ieee8021xProtocolTLS
+                      ) {
+                        <div class="network-form-upload">
+                          <span class="network-form-upload-label">{{
+                            'network.wirelessProfile.ieee8021xClientCert.value' | translate
+                          }}</span>
+                          <div class="network-form-upload-row">
+                            <button type="button" mat-stroked-button color="primary" (click)="clientCertInput.click()">
+                              {{ 'common.chooseFile.value' | translate }}
+                            </button>
+                            <input
+                              hidden
+                              #clientCertInput
+                              type="file"
+                              accept=".pem,.crt,.cer,.der"
+                              (change)="onClientCertSelected($event)" />
+                            @if (
+                              clientCertFileName() !== '' ||
+                              wirelessProfileForm.controls.ieee8021xClientCert.value !== ''
+                            ) {
+                              <span class="network-form-upload-status">
+                                <mat-icon color="primary">check_circle</mat-icon>
+                                {{
+                                  clientCertFileName() ||
+                                    ('network.wirelessProfile.ieee8021xCertUploaded.value' | translate)
+                                }}
+                              </span>
+                            } @else {
+                              <span class="network-form-upload-status">
+                                <mat-icon color="warn">remove_circle</mat-icon>
+                                {{ 'network.wirelessProfile.ieee8021xCertNotUploaded.value' | translate }}
+                              </span>
+                            }
+                          </div>
+                          @if (
+                            wirelessProfileForm.controls.ieee8021xClientCert.invalid &&
+                            wirelessProfileForm.controls.ieee8021xClientCert.touched
+                          ) {
+                            <mat-error>{{
+                              'network.wirelessProfile.ieee8021xClientCertRequired.value' | translate
+                            }}</mat-error>
+                          }
+                        </div>
+
+                        <div class="network-form-upload">
+                          <span class="network-form-upload-label">{{
+                            'network.wirelessProfile.ieee8021xPrivateKey.value' | translate
+                          }}</span>
+                          <div class="network-form-upload-row">
+                            <button type="button" mat-stroked-button color="primary" (click)="privateKeyInput.click()">
+                              {{ 'common.chooseFile.value' | translate }}
+                            </button>
+                            <input
+                              hidden
+                              #privateKeyInput
+                              type="file"
+                              accept=".pem,.key,.der"
+                              (change)="onPrivateKeySelected($event)" />
+                            @if (
+                              privateKeyFileName() !== '' ||
+                              wirelessProfileForm.controls.ieee8021xPrivateKey.value !== ''
+                            ) {
+                              <span class="network-form-upload-status">
+                                <mat-icon color="primary">check_circle</mat-icon>
+                                {{
+                                  privateKeyFileName() ||
+                                    ('network.wirelessProfile.ieee8021xCertUploaded.value' | translate)
+                                }}
+                              </span>
+                            } @else {
+                              <span class="network-form-upload-status">
+                                <mat-icon color="warn">remove_circle</mat-icon>
+                                {{ 'network.wirelessProfile.ieee8021xCertNotUploaded.value' | translate }}
+                              </span>
+                            }
+                          </div>
+                          @if (
+                            wirelessProfileForm.controls.ieee8021xPrivateKey.invalid &&
+                            wirelessProfileForm.controls.ieee8021xPrivateKey.touched
+                          ) {
+                            <mat-error>{{
+                              'network.wirelessProfile.ieee8021xPrivateKeyRequired.value' | translate
+                            }}</mat-error>
+                          }
+                        </div>
+                      }
+
+                      <div class="network-form-upload">
+                        <span class="network-form-upload-label">{{
+                          'network.wirelessProfile.ieee8021xCACert.value' | translate
+                        }}</span>
+                        <div class="network-form-upload-row">
+                          <button type="button" mat-stroked-button color="primary" (click)="caCertInput.click()">
+                            {{ 'common.chooseFile.value' | translate }}
+                          </button>
+                          <input
+                            hidden
+                            #caCertInput
+                            type="file"
+                            accept=".pem,.crt,.cer,.der"
+                            (change)="onCACertSelected($event)" />
+                          @if (caCertFileName() !== '' || wirelessProfileForm.controls.ieee8021xCACert.value !== '') {
+                            <span class="network-form-upload-status">
+                              <mat-icon color="primary">check_circle</mat-icon>
+                              {{
+                                caCertFileName() || ('network.wirelessProfile.ieee8021xCertUploaded.value' | translate)
+                              }}
+                            </span>
+                          }
+                        </div>
+                        <span class="like-mat-hint">{{
+                          'network.wirelessProfile.ieee8021xCACertHint.value' | translate
+                        }}</span>
+                      </div>
+                    }
+                  </div>
+
+                  <div class="network-form-actions">
+                    <button mat-button type="button" (click)="resetWirelessProfileForm()">
+                      {{ 'common.cancelLower.value' | translate }}
+                    </button>
+                    <button
+                      mat-flat-button
+                      color="primary"
+                      type="submit"
+                      [disabled]="isSavingWirelessProfile() || wirelessProfileForm.invalid">
+                      {{
+                        editingWirelessProfileName() == null
+                          ? ('common.save.value' | translate)
+                          : ('common.update.value' | translate)
+                      }}
+                    </button>
+                  </div>
+                </form>
+              }
+
+              <div class="network-form">
+                @if (wirelessProfiles().length > 0) {
+                  <mat-list class="wireless-profile-list">
+                    @for (profile of wirelessProfiles(); track profile.profileName) {
+                      <mat-list-item class="wireless-profile-item">
+                        <mat-icon matListItemIcon>wifi</mat-icon>
+                        <div matListItemTitle>{{ profile.profileName }} ({{ profile.ssid }})</div>
+                        <div matListItemLine>
+                          {{ profile.authenticationMethod }} | {{ profile.encryptionMethod }} |
+                          {{ 'network.wirelessProfile.priority.value' | translate }}: {{ profile.priority }}
+                        </div>
+                        <div matListItemMeta class="profile-actions">
+                          <button
+                            mat-icon-button
+                            type="button"
+                            [attr.aria-label]="'network.wirelessProfile.edit.value' | translate"
+                            [matTooltip]="'network.wirelessProfile.edit.value' | translate"
+                            (click)="editWirelessProfile(profile)">
+                            <mat-icon>edit</mat-icon>
+                          </button>
+                          <button
+                            mat-icon-button
+                            type="button"
+                            [attr.aria-label]="'common.delete.value' | translate"
+                            [matTooltip]="'common.delete.value' | translate"
+                            (click)="deleteWirelessProfile(profile.profileName)">
+                            <mat-icon>delete</mat-icon>
+                          </button>
+                        </div>
+                      </mat-list-item>
+                    }
+                  </mat-list>
+                } @else {
+                  <p class="like-mat-hint">{{ 'network.wirelessProfile.empty.value' | translate }}</p>
+                }
+              </div>
+            </mat-card-content>
+          }
+        </mat-card>
+      }
+    </div>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/devices/network-settings/network-settings.component.scss
+++ b/src/app/devices/network-settings/network-settings.component.scss
@@ -1,0 +1,184 @@
+@use '@angular/material' as mat;
+@use 'sass:map';
+
+.network-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.network-form-title {
+  font-weight: 600;
+}
+
+.network-form-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.network-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.network-form-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.profile-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.wireless-profile-list {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  padding: 0;
+}
+
+.wireless-profile-item:not(:last-child) {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.network-form-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.network-form-upload-label {
+  font-size: 75%;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.network-form-upload-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.network-form-upload-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 85%;
+}
+
+.like-mat-hint {
+  font-size: 75%;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.network-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 16px;
+}
+
+.network-tabs {
+  ::ng-deep .mat-mdc-tab .mdc-tab__text-label {
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+  }
+
+  ::ng-deep .mat-mdc-tab-body-content {
+    overflow-x: hidden;
+  }
+}
+
+.network-tab-icon {
+  margin-right: 8px;
+}
+
+.status-up {
+  color: map.get(mat.$m2-green-palette, 700);
+  font-weight: 600;
+}
+
+.status-down {
+  color: map.get(mat.$m2-red-palette, 700);
+  font-weight: 600;
+}
+
+.ieee-status-label {
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.ieee-status-text {
+  font-weight: 600;
+}
+
+.ieee-expand-icon {
+  flex: 0 0 auto;
+  margin-left: -20px;
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.ieee-sub-item {
+  p {
+    margin-left: 16px;
+    color: rgba(0, 0, 0, 0.6);
+  }
+}
+
+mat-card {
+  position: relative;
+
+  mat-progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+  }
+}
+
+.profile-add-button,
+.card-edit-button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 1;
+  font-weight: bold;
+}
+
+.network-config-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.network-config-section .network-form {
+  margin-bottom: 0;
+}
+
+@media (max-width: 960px) {
+  .network-form-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/devices/network-settings/network-settings.component.spec.ts
+++ b/src/app/devices/network-settings/network-settings.component.spec.ts
@@ -1,18 +1,39 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { NetworkSettingsComponent } from './network-settings.component'
+import { WifiDisabledAlertComponent } from '../../shared/wifi-disabled-alert/wifi-disabled-alert.component'
+import { NetworkChangeAlertComponent } from '../../shared/network-change-alert/network-change-alert.component'
 import { DevicesService } from '../devices.service'
-import { of } from 'rxjs'
+import { config, of, throwError } from 'rxjs'
 import { provideTranslateService } from '@ngx-translate/core'
+import { MatDialog, MatDialogRef } from '@angular/material/dialog'
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { HttpErrorResponse } from '@angular/common/http'
 
 describe('NetworkSettingsComponent', () => {
   let component: NetworkSettingsComponent
   let fixture: ComponentFixture<NetworkSettingsComponent>
   let devicesServiceSpy: jasmine.SpyObj<DevicesService>
+  let dialogOpenSpy: jasmine.Spy
+  let snackBarOpenSpy: jasmine.Spy
 
   beforeEach(async () => {
     devicesServiceSpy = jasmine.createSpyObj('DevicesService', [
-      'getNetworkSettings'
+      'getNetworkSettings',
+      'getWirelessState',
+      'getWirelessProfileSync',
+      'patchWiredNetworkSettings',
+      'requestWirelessStateChange',
+      'setWirelessProfileSync',
+      'getWirelessProfiles',
+      'addWirelessProfile',
+      'updateWirelessProfile',
+      'deleteWirelessProfile'
     ])
     devicesServiceSpy.getNetworkSettings.and.returnValue(
       of({
@@ -23,6 +44,19 @@ describe('NetworkSettingsComponent', () => {
         }
       } as any)
     )
+    devicesServiceSpy.getWirelessState.and.returnValue(of({ state: 'WifiEnabledS0SxAC' } as any))
+    devicesServiceSpy.getWirelessProfileSync.and.returnValue(
+      of({ localProfileSync: true, uefiProfileSync: false, uefiProfileSyncSupported: true } as any)
+    )
+    devicesServiceSpy.patchWiredNetworkSettings.and.returnValue(of(void 0))
+    devicesServiceSpy.requestWirelessStateChange.and.returnValue(of({ state: 'WifiEnabledS0SxAC' } as any))
+    devicesServiceSpy.setWirelessProfileSync.and.returnValue(
+      of({ localProfileSync: true, uefiProfileSync: false, uefiProfileSyncSupported: true } as any)
+    )
+    devicesServiceSpy.getWirelessProfiles.and.returnValue(of([]))
+    devicesServiceSpy.addWirelessProfile.and.returnValue(of(void 0))
+    devicesServiceSpy.updateWirelessProfile.and.returnValue(of(void 0))
+    devicesServiceSpy.deleteWirelessProfile.and.returnValue(of(void 0))
     TestBed.configureTestingModule({
       imports: [NetworkSettingsComponent],
       providers: [
@@ -33,10 +67,934 @@ describe('NetworkSettingsComponent', () => {
 
     fixture = TestBed.createComponent(NetworkSettingsComponent)
     component = fixture.componentInstance
+    snackBarOpenSpy = spyOn(fixture.debugElement.injector.get(MatSnackBar), 'open')
+    dialogOpenSpy = spyOn(fixture.debugElement.injector.get(MatDialog), 'open').and.returnValue({
+      afterClosed: () => of(true)
+    } as MatDialogRef<unknown>)
     fixture.detectChanges()
   })
 
+  const rebuildComponent = (): void => {
+    fixture = TestBed.createComponent(NetworkSettingsComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  }
+
+  // Several component flows intentionally re-throw via catchError without a subscriber
+  // error handler, so RxJS reports the error on a macrotask. This zoneless suite cannot
+  // use fakeAsync, so the action runs with RxJS's unhandled-error handler suppressed and
+  // a macrotask is awaited to let the re-thrown error drain without failing other specs.
+  const runAndSwallowRethrow = async (action: () => void): Promise<void> => {
+    const previous = config.onUnhandledError
+    config.onUnhandledError = () => undefined
+    try {
+      action()
+      await new Promise<void>((resolve) => setTimeout(resolve))
+    } finally {
+      config.onUnhandledError = previous
+    }
+  }
+
+  const createFileEvent = (name: string, content: string): Event => {
+    const file = new File([content], name)
+    const input = document.createElement('input')
+    Object.defineProperty(input, 'files', { value: [file], configurable: true })
+    return { target: input } as unknown as Event
+  }
+
+  const waitForCredential = (
+    control: 'ieee8021xClientCert' | 'ieee8021xPrivateKey' | 'ieee8021xCACert',
+    trigger: () => void
+  ): Promise<void> =>
+    new Promise((resolve) => {
+      const sub = component.wirelessProfileForm.controls[control].valueChanges.subscribe(() => {
+        sub.unsubscribe()
+        resolve()
+      })
+      trigger()
+    })
+
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('suppresses the error snackbar on a 409 conflict (handled by the global interceptor dialog)', () => {
+    snackBarOpenSpy.calls.reset()
+    ;(component as unknown as { showError: (m: string, e?: unknown) => void }).showError(
+      'msg',
+      new HttpErrorResponse({ status: 409 })
+    )
+    expect(snackBarOpenSpy).not.toHaveBeenCalled()
+  })
+
+  it('suppresses the error snackbar on a 412 conflict (handled by the global interceptor dialog)', () => {
+    snackBarOpenSpy.calls.reset()
+    ;(component as unknown as { showError: (m: string, e?: unknown) => void }).showError(
+      'msg',
+      new HttpErrorResponse({ status: 412 })
+    )
+    expect(snackBarOpenSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows the error snackbar for non-conflict HTTP failures', () => {
+    snackBarOpenSpy.calls.reset()
+    ;(component as unknown as { showError: (m: string, e?: unknown) => void }).showError(
+      'msg',
+      new HttpErrorResponse({ status: 500 })
+    )
+    expect(snackBarOpenSpy).toHaveBeenCalled()
+  })
+
+  it('shows the error snackbar when no error is provided', () => {
+    snackBarOpenSpy.calls.reset()
+    ;(component as unknown as { showError: (m: string, e?: unknown) => void }).showError('msg')
+    expect(snackBarOpenSpy).toHaveBeenCalled()
+  })
+
+  it('enables the UEFI profile sync toggle when the device reports support', () => {
+    expect(component.uefiProfileSyncSupported()).toBeTrue()
+    expect(component.wirelessSettingsForm.controls.uefiProfileSyncEnabled.enabled).toBeTrue()
+  })
+
+  it('disables and forces off the UEFI profile sync toggle when unsupported', () => {
+    devicesServiceSpy.getWirelessProfileSync.and.returnValue(
+      of({ localProfileSync: true, uefiProfileSync: true, uefiProfileSyncSupported: false } as any)
+    )
+
+    fixture = TestBed.createComponent(NetworkSettingsComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+
+    expect(component.uefiProfileSyncSupported()).toBeFalse()
+    expect(component.wirelessSettingsForm.controls.uefiProfileSyncEnabled.disabled).toBeTrue()
+    expect(component.wirelessSettingsForm.controls.uefiProfileSyncEnabled.value).toBeFalse()
+  })
+
+  it('keeps the UEFI toggle disabled after saving when still unsupported', () => {
+    devicesServiceSpy.getWirelessProfileSync.and.returnValue(
+      of({ localProfileSync: true, uefiProfileSync: false, uefiProfileSyncSupported: false } as any)
+    )
+    devicesServiceSpy.setWirelessProfileSync.and.returnValue(
+      of({ localProfileSync: true, uefiProfileSync: false, uefiProfileSyncSupported: false } as any)
+    )
+
+    fixture = TestBed.createComponent(NetworkSettingsComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+
+    component.saveWirelessSettings()
+
+    expect(component.uefiProfileSyncSupported()).toBeFalse()
+    expect(component.wirelessSettingsForm.controls.uefiProfileSyncEnabled.disabled).toBeTrue()
+    expect(component.wirelessSettingsForm.controls.uefiProfileSyncEnabled.value).toBeFalse()
+  })
+
+  it('reports wired 802.1x as disabled when no enabled value is present', () => {
+    component.networkResults.set({ wired: { ieee8021x: {} } } as any)
+    expect(component.isWiredIeee8021xEnabled()).toBeFalse()
+  })
+
+  it('reports wired 802.1x as disabled for an empty string or "Disabled"', () => {
+    component.networkResults.set({ wired: { ieee8021x: { enabled: '' } } } as any)
+    expect(component.isWiredIeee8021xEnabled()).toBeFalse()
+
+    component.networkResults.set({ wired: { ieee8021x: { enabled: 'Disabled' } } } as any)
+    expect(component.isWiredIeee8021xEnabled()).toBeFalse()
+  })
+
+  it('reports wired 802.1x as enabled for a non-disabled value', () => {
+    component.networkResults.set({ wired: { ieee8021x: { enabled: 'EnabledWithCertificates' } } } as any)
+    expect(component.isWiredIeee8021xEnabled()).toBeTrue()
+  })
+
+  it('toggles the wired 802.1x expanded state', () => {
+    expect(component.wiredIeee8021xExpanded()).toBeFalse()
+
+    component.toggleWiredIeee8021x()
+    expect(component.wiredIeee8021xExpanded()).toBeTrue()
+
+    component.toggleWiredIeee8021x()
+    expect(component.wiredIeee8021xExpanded()).toBeFalse()
+  })
+
+  it('toggles the wired configuration form visibility', () => {
+    expect(component.showWiredConfigForm()).toBeFalse()
+
+    component.toggleWiredConfigForm()
+    expect(component.showWiredConfigForm()).toBeTrue()
+
+    component.toggleWiredConfigForm()
+    expect(component.showWiredConfigForm()).toBeFalse()
+  })
+
+  it('toggles the wireless configuration form visibility', () => {
+    expect(component.showWirelessConfigForm()).toBeFalse()
+
+    component.toggleWirelessConfigForm()
+    expect(component.showWirelessConfigForm()).toBeTrue()
+
+    component.toggleWirelessConfigForm()
+    expect(component.showWirelessConfigForm()).toBeFalse()
+  })
+
+  it('reverts and hides the wired settings form when cancelling', () => {
+    component.networkResults.set({ wired: { dhcpEnabled: true, ipSyncEnabled: true } } as any)
+    component.showWiredConfigForm.set(true)
+    component.wiredForm.controls.dhcpEnabled.setValue(false)
+    component.wiredForm.markAsDirty()
+
+    component.cancelWiredSettings()
+
+    expect(component.wiredForm.controls.dhcpEnabled.value).toBeTrue()
+    expect(component.wiredForm.pristine).toBeTrue()
+    expect(component.showWiredConfigForm()).toBeFalse()
+  })
+
+  it('reverts and hides the wireless settings form when cancelling', () => {
+    component.wirelessStatus.set({ enabled: true, localProfileSyncEnabled: false, uefiProfileSyncEnabled: false })
+    component.showWirelessConfigForm.set(true)
+    component.wirelessSettingsForm.controls.enabled.setValue(false)
+    component.wirelessSettingsForm.markAsDirty()
+
+    component.cancelWirelessSettings()
+
+    expect(component.wirelessSettingsForm.controls.enabled.value).toBeTrue()
+    expect(component.wirelessSettingsForm.pristine).toBeTrue()
+    expect(component.showWirelessConfigForm()).toBeFalse()
+  })
+
+  it('closes the add profile form without a dialog when toggled shut', () => {
+    component.wirelessStatus.set({ enabled: false, localProfileSyncEnabled: false, uefiProfileSyncEnabled: false })
+    component.showWirelessProfileForm.set(true)
+    component.editingWirelessProfileName.set(null)
+    dialogOpenSpy.calls.reset()
+
+    component.toggleWirelessProfileForm()
+
+    expect(dialogOpenSpy).not.toHaveBeenCalled()
+    expect(component.showWirelessProfileForm()).toBeFalse()
+  })
+
+  it('opens the add profile form through the WiFi-disabled warning when toggled open', () => {
+    component.wirelessStatus.set({ enabled: false, localProfileSyncEnabled: false, uefiProfileSyncEnabled: false })
+    component.showWirelessProfileForm.set(false)
+
+    component.toggleWirelessProfileForm()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(WifiDisabledAlertComponent)
+    expect(component.showWirelessProfileForm()).toBeTrue()
+  })
+
+  it('reloads the read-only network details after saving wireless settings', () => {
+    devicesServiceSpy.getNetworkSettings.calls.reset()
+
+    component.saveWirelessSettings()
+
+    expect(devicesServiceSpy.getNetworkSettings).toHaveBeenCalledTimes(1)
+    expect(component.isRefreshingNetwork()).toBeFalse()
+  })
+
+  it('refreshes the wireless profile list after saving a profile', () => {
+    component.wirelessProfileForm.patchValue({
+      profileName: 'profile1',
+      ssid: 'ssid1',
+      priority: 1,
+      authenticationMethod: 'WPA2PSK',
+      encryptionMethod: 'CCMP',
+      password: 'password1'
+    })
+    devicesServiceSpy.getWirelessProfiles.calls.reset()
+    devicesServiceSpy.getWirelessProfiles.and.returnValue(
+      of([{ profileName: 'profile1', ssid: 'ssid1', priority: 1 }] as any)
+    )
+
+    component.saveWirelessProfile()
+
+    expect(devicesServiceSpy.getWirelessProfiles).toHaveBeenCalledTimes(1)
+    expect(component.wirelessProfiles().length).toBe(1)
+    expect(component.isLoadingWirelessProfiles()).toBeFalse()
+  })
+
+  it('does not flag the wireless profile limit when fewer than the maximum exist', () => {
+    component.wirelessProfiles.set(
+      Array.from({ length: component.maxWirelessProfiles - 1 }, (_, i) => ({
+        profileName: `profile${i}`,
+        ssid: `ssid${i}`,
+        priority: i + 1
+      })) as any
+    )
+
+    expect(component.isWirelessProfileLimitReached()).toBeFalse()
+  })
+
+  it('flags the wireless profile limit once the maximum number of profiles exist', () => {
+    component.wirelessProfiles.set(
+      Array.from({ length: component.maxWirelessProfiles }, (_, i) => ({
+        profileName: `profile${i}`,
+        ssid: `ssid${i}`,
+        priority: i + 1
+      })) as any
+    )
+
+    expect(component.isWirelessProfileLimitReached()).toBeTrue()
+  })
+
+  it('disables the add wireless profile button when the maximum number of profiles is reached', () => {
+    component.selectedTabIndex.set(1)
+    component.wirelessProfiles.set(
+      Array.from({ length: component.maxWirelessProfiles }, (_, i) => ({
+        profileName: `profile${i}`,
+        ssid: `ssid${i}`,
+        priority: i + 1
+      })) as any
+    )
+    fixture.detectChanges()
+
+    const addButton: HTMLButtonElement | null = fixture.nativeElement.querySelector('.profile-add-button')
+    expect(addButton).not.toBeNull()
+    expect(addButton?.disabled).toBeTrue()
+  })
+
+  it('starts a new wireless profile with an empty priority', () => {
+    component.addNewWirelessProfile()
+
+    expect(component.wirelessProfileForm.controls.priority.value).toBeNull()
+    expect(component.wirelessProfileForm.controls.priority.hasError('required')).toBeTrue()
+  })
+
+  it('warns with a dialog but still opens the form when adding a profile while WiFi is disabled', () => {
+    component.wirelessStatus.set({ enabled: false, localProfileSyncEnabled: false, uefiProfileSyncEnabled: false })
+
+    component.addNewWirelessProfile()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(WifiDisabledAlertComponent)
+    expect(component.showWirelessProfileForm()).toBeTrue()
+  })
+
+  it('does not open the WiFi disabled dialog when adding a profile while WiFi is enabled', () => {
+    component.wirelessStatus.set({ enabled: true, localProfileSyncEnabled: false, uefiProfileSyncEnabled: false })
+    dialogOpenSpy.calls.reset()
+
+    component.addNewWirelessProfile()
+
+    expect(dialogOpenSpy).not.toHaveBeenCalledWith(WifiDisabledAlertComponent)
+    expect(component.showWirelessProfileForm()).toBeTrue()
+  })
+
+  it('flags a priority already used by another wireless profile', () => {
+    component.wirelessProfiles.set([{ profileName: 'profile1', ssid: 'ssid1', priority: 2 }] as any)
+    component.addNewWirelessProfile()
+
+    component.wirelessProfileForm.controls.priority.setValue(2)
+
+    expect(component.wirelessProfileForm.controls.priority.hasError('priorityConflict')).toBeTrue()
+  })
+
+  it('accepts a priority that is not used by any other wireless profile', () => {
+    component.wirelessProfiles.set([{ profileName: 'profile1', ssid: 'ssid1', priority: 2 }] as any)
+    component.addNewWirelessProfile()
+
+    component.wirelessProfileForm.controls.priority.setValue(3)
+
+    expect(component.wirelessProfileForm.controls.priority.hasError('priorityConflict')).toBeFalse()
+  })
+
+  it('does not flag the edited profile against its own priority', () => {
+    const profile = { profileName: 'profile1', ssid: 'ssid1', priority: 2 } as any
+    component.wirelessProfiles.set([profile])
+
+    component.editWirelessProfile(profile)
+
+    expect(component.wirelessProfileForm.controls.priority.value).toBe(2)
+    expect(component.wirelessProfileForm.controls.priority.hasError('priorityConflict')).toBeFalse()
+  })
+
+  it('blocks non-numeric keys on the priority field', () => {
+    for (const key of [
+      'e',
+      'E',
+      '+',
+      '-',
+      '.'
+    ]) {
+      const event = new KeyboardEvent('keydown', { key })
+      spyOn(event, 'preventDefault')
+
+      component.blockNonNumericKey(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+    }
+  })
+
+  it('allows numeric keys on the priority field', () => {
+    const event = new KeyboardEvent('keydown', { key: '5' })
+    spyOn(event, 'preventDefault')
+
+    component.blockNonNumericKey(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('shows an error and clears the loading flags when the network settings request fails', async () => {
+    devicesServiceSpy.getNetworkSettings.and.returnValue(throwError(() => new Error('boom')))
+    snackBarOpenSpy.calls.reset()
+
+    await runAndSwallowRethrow(() => rebuildComponent())
+
+    expect(snackBarOpenSpy).toHaveBeenCalled()
+    expect(component.isWiredLoading()).toBeFalse()
+    expect(component.isWirelessLoading()).toBeFalse()
+    expect(component.isWirelessConfigLoading()).toBeFalse()
+  })
+
+  it('selects the wireless tab when the device has no wired adapter', () => {
+    devicesServiceSpy.getNetworkSettings.and.returnValue(
+      of({ wired: null, wireless: { wifiNetworks: [], ieee8021xSettings: [] } } as any)
+    )
+
+    rebuildComponent()
+
+    expect(component.selectedTabIndex()).toBe(1)
+  })
+
+  it('stops the wireless config spinner when the device has no wireless adapter', () => {
+    devicesServiceSpy.getNetworkSettings.and.returnValue(of({ wired: { ieee8021x: {} }, wireless: null } as any))
+
+    rebuildComponent()
+
+    expect(component.isWirelessConfigLoading()).toBeFalse()
+  })
+
+  it('reports adapters as present while the settings are still loading', () => {
+    component.isWiredLoading.set(true)
+    component.isWirelessLoading.set(true)
+    component.networkResults.set({ wired: null, wireless: null } as any)
+
+    expect(component.hasWiredAdapter()).toBeTrue()
+    expect(component.hasWirelessAdapter()).toBeTrue()
+  })
+
+  it('reports adapter availability from the loaded settings once loading completes', () => {
+    component.isWiredLoading.set(false)
+    component.isWirelessLoading.set(false)
+
+    component.networkResults.set({ wired: { ieee8021x: {} }, wireless: {} } as any)
+    expect(component.hasWiredAdapter()).toBeTrue()
+    expect(component.hasWirelessAdapter()).toBeTrue()
+
+    component.networkResults.set({ wired: null, wireless: null } as any)
+    expect(component.hasWiredAdapter()).toBeFalse()
+    expect(component.hasWirelessAdapter()).toBeFalse()
+  })
+
+  it('does not call the backend when the wired form is invalid', () => {
+    devicesServiceSpy.patchWiredNetworkSettings.calls.reset()
+    component.wiredForm.controls.dhcpEnabled.setValue(false)
+    component.wiredForm.controls.ipSyncEnabled.setValue(false)
+    component.wiredForm.controls.ipAddress.setValue('')
+
+    component.saveWiredSettings()
+
+    expect(devicesServiceSpy.patchWiredNetworkSettings).not.toHaveBeenCalled()
+    expect(component.wiredForm.touched).toBeTrue()
+  })
+
+  it('confirms before saving wired settings and aborts when the dialog is dismissed', () => {
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(false) } as MatDialogRef<unknown>)
+    devicesServiceSpy.patchWiredNetworkSettings.calls.reset()
+    component.wiredForm.controls.dhcpEnabled.setValue(true)
+
+    component.saveWiredSettings()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(NetworkChangeAlertComponent, jasmine.any(Object))
+    expect(devicesServiceSpy.patchWiredNetworkSettings).not.toHaveBeenCalled()
+  })
+
+  it('warns about a possible connection drop before saving wired settings', () => {
+    component.wiredForm.controls.dhcpEnabled.setValue(true)
+
+    component.saveWiredSettings()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(
+      NetworkChangeAlertComponent,
+      jasmine.objectContaining({ data: { messageKey: 'network.changeAlert.message.value' } })
+    )
+  })
+
+  it('saves wired settings with a DHCP payload and refreshes the read-only details', () => {
+    devicesServiceSpy.getNetworkSettings.calls.reset()
+    component.wiredForm.controls.dhcpEnabled.setValue(true)
+
+    component.saveWiredSettings()
+
+    expect(devicesServiceSpy.patchWiredNetworkSettings).toHaveBeenCalledWith(
+      jasmine.any(String),
+      jasmine.objectContaining({ dhcpEnabled: true, ipSyncEnabled: true })
+    )
+    expect(component.isSavingWired()).toBeFalse()
+    expect(devicesServiceSpy.getNetworkSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('includes the static IP fields when DHCP and IP sync are both disabled', () => {
+    component.wiredForm.controls.dhcpEnabled.setValue(false)
+    component.wiredForm.controls.ipSyncEnabled.setValue(false)
+    component.wiredForm.patchValue({
+      ipAddress: '192.168.1.10',
+      subnetMask: '255.255.255.0',
+      defaultGateway: '192.168.1.1',
+      primaryDNS: '8.8.8.8',
+      secondaryDNS: '8.8.4.4'
+    })
+
+    component.saveWiredSettings()
+
+    expect(devicesServiceSpy.patchWiredNetworkSettings).toHaveBeenCalledWith(
+      jasmine.any(String),
+      jasmine.objectContaining({
+        dhcpEnabled: false,
+        ipSyncEnabled: false,
+        ipAddress: '192.168.1.10',
+        subnetMask: '255.255.255.0',
+        defaultGateway: '192.168.1.1',
+        primaryDNS: '8.8.8.8',
+        secondaryDNS: '8.8.4.4'
+      })
+    )
+  })
+
+  it('shows an error when saving wired settings fails', async () => {
+    devicesServiceSpy.patchWiredNetworkSettings.and.returnValue(throwError(() => new Error('fail')))
+    snackBarOpenSpy.calls.reset()
+    component.wiredForm.controls.dhcpEnabled.setValue(true)
+
+    await runAndSwallowRethrow(() => component.saveWiredSettings())
+
+    expect(snackBarOpenSpy).toHaveBeenCalled()
+    expect(component.isSavingWired()).toBeFalse()
+  })
+
+  it('ignores a null result when refreshing the read-only network details', () => {
+    component.wiredForm.controls.dhcpEnabled.setValue(true)
+    const previous = component.networkResults()
+    devicesServiceSpy.getNetworkSettings.and.returnValue(of(null as any))
+
+    component.saveWiredSettings()
+
+    expect(component.isRefreshingNetwork()).toBeFalse()
+    expect(component.networkResults()).toBe(previous)
+  })
+
+  it('recovers when refreshing the read-only network details fails', () => {
+    component.wiredForm.controls.dhcpEnabled.setValue(true)
+    devicesServiceSpy.getNetworkSettings.and.returnValue(throwError(() => new Error('fail')))
+
+    component.saveWiredSettings()
+
+    expect(component.isRefreshingNetwork()).toBeFalse()
+  })
+
+  it('disables IP sync when the loaded wired settings use DHCP', () => {
+    devicesServiceSpy.getNetworkSettings.and.returnValue(
+      of({ wired: { dhcpEnabled: true, ieee8021x: {} }, wireless: null } as any)
+    )
+
+    rebuildComponent()
+
+    expect(component.wiredForm.controls.dhcpEnabled.value).toBeTrue()
+    expect(component.wiredForm.controls.ipSyncEnabled.disabled).toBeTrue()
+  })
+
+  it('reloads the wireless configuration when saving wireless settings fails', async () => {
+    devicesServiceSpy.requestWirelessStateChange.and.returnValue(throwError(() => new Error('fail')))
+    devicesServiceSpy.getWirelessState.and.returnValue(throwError(() => new Error('fail')))
+    devicesServiceSpy.getWirelessProfileSync.and.returnValue(throwError(() => new Error('fail')))
+    devicesServiceSpy.setWirelessProfileSync.calls.reset()
+    devicesServiceSpy.getWirelessState.calls.reset()
+    snackBarOpenSpy.calls.reset()
+
+    await runAndSwallowRethrow(() => component.saveWirelessSettings())
+
+    expect(devicesServiceSpy.setWirelessProfileSync).not.toHaveBeenCalled()
+    expect(devicesServiceSpy.getWirelessState).toHaveBeenCalled()
+    expect(component.isSavingWireless()).toBeFalse()
+    expect(component.wirelessSettingsForm.enabled).toBeTrue()
+  })
+
+  it('confirms before saving wireless settings and aborts when the dialog is dismissed', () => {
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(false) } as MatDialogRef<unknown>)
+    devicesServiceSpy.requestWirelessStateChange.calls.reset()
+
+    component.saveWirelessSettings()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(NetworkChangeAlertComponent, jasmine.any(Object))
+    expect(devicesServiceSpy.requestWirelessStateChange).not.toHaveBeenCalled()
+  })
+
+  it('shows the general warning when saving wireless settings without disabling WiFi', () => {
+    component.wirelessSettingsForm.controls.enabled.setValue(true)
+
+    component.saveWirelessSettings()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(
+      NetworkChangeAlertComponent,
+      jasmine.objectContaining({ data: { messageKey: 'network.changeAlert.message.value' } })
+    )
+  })
+
+  it('warns to use the wired adapter when disabling WiFi on a device that has one', () => {
+    component.wirelessSettingsForm.controls.enabled.setValue(false)
+
+    component.saveWirelessSettings()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(
+      NetworkChangeAlertComponent,
+      jasmine.objectContaining({ data: { messageKey: 'network.changeAlert.wifiDisableWithWired.value' } })
+    )
+  })
+
+  it('warns there is no way to reconnect when disabling WiFi on a device with no wired adapter', () => {
+    component.isWiredLoading.set(false)
+    component.networkResults.set({ wired: null, wireless: {} } as any)
+    component.wirelessSettingsForm.controls.enabled.setValue(false)
+
+    component.saveWirelessSettings()
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(
+      NetworkChangeAlertComponent,
+      jasmine.objectContaining({ data: { messageKey: 'network.changeAlert.wifiDisableNoWired.value' } })
+    )
+  })
+
+  it('sends a WifiDisabled state when wireless is turned off', () => {
+    component.wirelessSettingsForm.controls.enabled.setValue(false)
+    devicesServiceSpy.requestWirelessStateChange.calls.reset()
+    devicesServiceSpy.requestWirelessStateChange.and.returnValue(of({ state: 'WifiDisabled' } as any))
+
+    component.saveWirelessSettings()
+
+    expect(devicesServiceSpy.requestWirelessStateChange).toHaveBeenCalledWith(
+      jasmine.any(String),
+      jasmine.objectContaining({ state: 'WifiDisabled' })
+    )
+  })
+
+  it('captures the device wireless status into the read-only snapshot on load', () => {
+    expect(component.wirelessStatus()).toEqual({
+      enabled: true,
+      localProfileSyncEnabled: true,
+      uefiProfileSyncEnabled: false
+    })
+  })
+
+  it('does not change the read-only status snapshot while editing the wireless form', () => {
+    const before = component.wirelessStatus()
+
+    component.wirelessSettingsForm.controls.enabled.setValue(false)
+    component.wirelessSettingsForm.controls.localProfileSyncEnabled.setValue(false)
+    component.wirelessSettingsForm.controls.uefiProfileSyncEnabled.setValue(true)
+
+    expect(component.wirelessStatus()).toEqual(before)
+  })
+
+  it('updates the read-only status snapshot after a successful save', () => {
+    devicesServiceSpy.requestWirelessStateChange.and.returnValue(of({ state: 'WifiDisabled' } as any))
+    devicesServiceSpy.setWirelessProfileSync.and.returnValue(
+      of({ localProfileSync: false, uefiProfileSync: true, uefiProfileSyncSupported: true } as any)
+    )
+
+    component.saveWirelessSettings()
+
+    expect(component.wirelessStatus()).toEqual({
+      enabled: false,
+      localProfileSyncEnabled: false,
+      uefiProfileSyncEnabled: true
+    })
+  })
+
+  it('leaves the read-only status snapshot undefined when the device status fails to load', () => {
+    devicesServiceSpy.getWirelessState.and.returnValue(throwError(() => new Error('fail')))
+    devicesServiceSpy.getWirelessProfileSync.and.returnValue(throwError(() => new Error('fail')))
+
+    rebuildComponent()
+
+    expect(component.wirelessStatus()).toEqual({
+      enabled: false,
+      localProfileSyncEnabled: false,
+      uefiProfileSyncEnabled: false
+    })
+  })
+
+  it('falls back to the current wireless settings when the wireless card data fails to load', () => {
+    devicesServiceSpy.getWirelessState.and.returnValue(throwError(() => new Error('fail')))
+    devicesServiceSpy.getWirelessProfileSync.and.returnValue(throwError(() => new Error('fail')))
+    devicesServiceSpy.getWirelessProfiles.and.returnValue(throwError(() => new Error('fail')))
+
+    rebuildComponent()
+
+    expect(component.isWirelessConfigLoading()).toBeFalse()
+    expect(component.wirelessProfiles()).toEqual([])
+    expect(component.uefiProfileSyncSupported()).toBeTrue()
+  })
+
+  it('repopulates the wireless toggles from the reloaded configuration after a failed save', async () => {
+    devicesServiceSpy.requestWirelessStateChange.and.returnValue(throwError(() => new Error('fail')))
+    devicesServiceSpy.getWirelessState.and.returnValue(of({ state: 'WifiEnabledS0SxAC' } as any))
+    devicesServiceSpy.getWirelessProfileSync.and.returnValue(
+      of({ localProfileSync: true, uefiProfileSync: false, uefiProfileSyncSupported: true } as any)
+    )
+
+    await runAndSwallowRethrow(() => component.saveWirelessSettings())
+
+    expect(component.wirelessSettingsForm.controls.enabled.value).toBeTrue()
+  })
+
+  it('sorts wireless profiles by ascending priority', () => {
+    devicesServiceSpy.getWirelessProfiles.and.returnValue(
+      of([
+        { profileName: 'b', ssid: 'b', priority: 3 },
+        { profileName: 'a', ssid: 'a', priority: 1 }
+      ] as any)
+    )
+
+    rebuildComponent()
+
+    expect(component.wirelessProfiles().map((p) => p.profileName)).toEqual(['a', 'b'])
+  })
+
+  it('does not save a wireless profile when the form is invalid', () => {
+    devicesServiceSpy.addWirelessProfile.calls.reset()
+    component.resetWirelessProfileForm()
+
+    component.saveWirelessProfile()
+
+    expect(devicesServiceSpy.addWirelessProfile).not.toHaveBeenCalled()
+  })
+
+  it('builds an 802.1x TLS payload when adding a certificate-based wireless profile', () => {
+    component.addNewWirelessProfile()
+    component.wirelessProfileForm.patchValue({
+      profileName: 'corpprofile',
+      ssid: 'corp',
+      priority: 1,
+      authenticationMethod: 'WPA2IEEE8021x',
+      encryptionMethod: 'CCMP',
+      ieee8021xUsername: 'user1',
+      ieee8021xAuthenticationProtocol: 0,
+      ieee8021xClientCert: 'CLIENTCERT',
+      ieee8021xPrivateKey: 'PRIVATEKEY',
+      ieee8021xCACert: 'CACERT'
+    })
+
+    component.saveWirelessProfile()
+
+    expect(devicesServiceSpy.addWirelessProfile).toHaveBeenCalledWith(
+      jasmine.any(String),
+      jasmine.objectContaining({
+        profileName: 'corpprofile',
+        ieee8021x: jasmine.objectContaining({
+          username: 'user1',
+          authenticationProtocol: 0,
+          clientCert: 'CLIENTCERT',
+          privateKey: 'PRIVATEKEY',
+          caCert: 'CACERT'
+        })
+      })
+    )
+  })
+
+  it('builds an 802.1x PEAP payload and updates an existing profile', () => {
+    component.editingWirelessProfileName.set('corpprofile')
+    component.showWirelessProfileForm.set(true)
+    component.wirelessProfileForm.controls.profileName.disable()
+    component.wirelessProfileForm.patchValue({
+      profileName: 'corpprofile',
+      ssid: 'corp',
+      priority: 1,
+      authenticationMethod: 'WPA2IEEE8021x',
+      encryptionMethod: 'CCMP',
+      ieee8021xUsername: 'user1',
+      ieee8021xAuthenticationProtocol: 2,
+      ieee8021xPassword: 'secret'
+    })
+
+    component.saveWirelessProfile()
+
+    expect(devicesServiceSpy.updateWirelessProfile).toHaveBeenCalledWith(
+      jasmine.any(String),
+      jasmine.objectContaining({
+        ieee8021x: jasmine.objectContaining({ authenticationProtocol: 2, password: 'secret' })
+      })
+    )
+  })
+
+  it('shows an error when saving a wireless profile fails', async () => {
+    devicesServiceSpy.addWirelessProfile.and.returnValue(throwError(() => new Error('fail')))
+    snackBarOpenSpy.calls.reset()
+    component.addNewWirelessProfile()
+    component.wirelessProfileForm.patchValue({
+      profileName: 'p1',
+      ssid: 's1',
+      priority: 1,
+      authenticationMethod: 'WPA2PSK',
+      encryptionMethod: 'CCMP',
+      password: 'password1'
+    })
+
+    await runAndSwallowRethrow(() => component.saveWirelessProfile())
+
+    expect(snackBarOpenSpy).toHaveBeenCalled()
+    expect(component.isSavingWirelessProfile()).toBeFalse()
+  })
+
+  it('falls back to an empty wireless profile list when reloading after a save fails', () => {
+    devicesServiceSpy.getWirelessProfiles.and.returnValue(throwError(() => new Error('fail')))
+    component.addNewWirelessProfile()
+    component.wirelessProfileForm.patchValue({
+      profileName: 'p1',
+      ssid: 's1',
+      priority: 1,
+      authenticationMethod: 'WPA2PSK',
+      encryptionMethod: 'CCMP',
+      password: 'password1'
+    })
+
+    component.saveWirelessProfile()
+
+    expect(component.wirelessProfiles()).toEqual([])
+    expect(component.isLoadingWirelessProfiles()).toBeFalse()
+  })
+
+  it('populates the 802.1x fields when editing a certificate-based profile', () => {
+    const profile = {
+      profileName: 'corp',
+      ssid: 'corp',
+      priority: 3,
+      authenticationMethod: 'WPA2IEEE8021x',
+      encryptionMethod: 'CCMP',
+      ieee8021x: { username: 'user1', authenticationProtocol: 2 }
+    } as any
+    component.wirelessProfiles.set([profile])
+
+    component.editWirelessProfile(profile)
+
+    expect(component.wirelessProfileForm.controls.ieee8021xUsername.value).toBe('user1')
+    expect(component.wirelessProfileForm.controls.ieee8021xAuthenticationProtocol.value).toBe(2)
+    expect(component.editingWirelessProfileName()).toBe('corp')
+    expect(component.wirelessProfileForm.controls.profileName.disabled).toBeTrue()
+  })
+
+  it('deletes a wireless profile after confirmation and resets the form when editing it', () => {
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(true) } as MatDialogRef<unknown>)
+    component.editingWirelessProfileName.set('p1')
+    devicesServiceSpy.getWirelessProfiles.calls.reset()
+    snackBarOpenSpy.calls.reset()
+
+    component.deleteWirelessProfile('p1')
+
+    expect(devicesServiceSpy.deleteWirelessProfile).toHaveBeenCalledWith(jasmine.any(String), 'p1')
+    expect(snackBarOpenSpy).toHaveBeenCalled()
+    expect(component.editingWirelessProfileName()).toBeNull()
+    expect(component.isSavingWirelessProfile()).toBeFalse()
+    expect(devicesServiceSpy.getWirelessProfiles).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not delete a wireless profile when the confirmation is dismissed', () => {
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(false) } as MatDialogRef<unknown>)
+    devicesServiceSpy.deleteWirelessProfile.calls.reset()
+
+    component.deleteWirelessProfile('p1')
+
+    expect(devicesServiceSpy.deleteWirelessProfile).not.toHaveBeenCalled()
+  })
+
+  it('shows an error when deleting a wireless profile fails', async () => {
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(true) } as MatDialogRef<unknown>)
+    devicesServiceSpy.deleteWirelessProfile.and.returnValue(throwError(() => new Error('fail')))
+    snackBarOpenSpy.calls.reset()
+
+    await runAndSwallowRethrow(() => component.deleteWirelessProfile('p1'))
+
+    expect(snackBarOpenSpy).toHaveBeenCalled()
+    expect(component.isSavingWirelessProfile()).toBeFalse()
+  })
+
+  it('reads a PEM certificate file and stores the stripped base64 body', async () => {
+    const pem = '-----BEGIN CERTIFICATE-----\nABC123DEF456\n-----END CERTIFICATE-----\n'
+    const event = createFileEvent('cert.pem', pem)
+
+    await waitForCredential('ieee8021xClientCert', () => component.onClientCertSelected(event))
+
+    expect(component.wirelessProfileForm.controls.ieee8021xClientCert.value).toBe('ABC123DEF456')
+    expect(component.clientCertFileName()).toBe('cert.pem')
+  })
+
+  it('reads a binary key file and stores its base64 contents', async () => {
+    const event = createFileEvent('key.der', 'binarydata')
+
+    await waitForCredential('ieee8021xPrivateKey', () => component.onPrivateKeySelected(event))
+
+    expect(component.wirelessProfileForm.controls.ieee8021xPrivateKey.value.length).toBeGreaterThan(0)
+    expect(component.privateKeyFileName()).toBe('key.der')
+  })
+
+  it('reads a PEM CA certificate through the CA cert input', async () => {
+    const pem = '-----BEGIN CERTIFICATE-----\nCACONTENT\n-----END CERTIFICATE-----'
+    const event = createFileEvent('ca.crt', pem)
+
+    await waitForCredential('ieee8021xCACert', () => component.onCACertSelected(event))
+
+    expect(component.wirelessProfileForm.controls.ieee8021xCACert.value).toBe('CACONTENT')
+    expect(component.caCertFileName()).toBe('ca.crt')
+  })
+
+  it('ignores a credential file selection when no file is provided', () => {
+    const input = document.createElement('input')
+    Object.defineProperty(input, 'files', { value: [], configurable: true })
+    const event = { target: input } as unknown as Event
+
+    component.onClientCertSelected(event)
+
+    expect(component.wirelessProfileForm.controls.ieee8021xClientCert.value).toBe('')
+    expect(component.clientCertFileName()).toBe('')
+  })
+
+  it('skips reading a credential file when FileReader is unavailable', () => {
+    const original = (window as unknown as { FileReader: unknown }).FileReader
+    ;(window as unknown as { FileReader: unknown }).FileReader = undefined
+    try {
+      const event = createFileEvent('cert.pem', 'data')
+
+      component.onClientCertSelected(event)
+
+      expect(component.clientCertFileName()).toBe('')
+    } finally {
+      ;(window as unknown as { FileReader: unknown }).FileReader = original
+    }
+  })
+
+  it('stores the raw data URL when a binary credential file lacks a base64 marker', async () => {
+    const original = (window as unknown as { FileReader: unknown }).FileReader
+    class FakeFileReader {
+      public onload: ((e: ProgressEvent<FileReader>) => void) | null = null
+      public result: string | null = null
+      public readAsDataURL(): void {
+        this.result = 'data:notbase64-content'
+        this.onload?.({ target: this as unknown as FileReader } as ProgressEvent<FileReader>)
+      }
+      public readAsText(): void {
+        this.result = ''
+        this.onload?.({ target: this as unknown as FileReader } as ProgressEvent<FileReader>)
+      }
+    }
+    ;(window as unknown as { FileReader: unknown }).FileReader = FakeFileReader
+    try {
+      const event = createFileEvent('key.der', 'whatever')
+
+      await waitForCredential('ieee8021xPrivateKey', () => component.onPrivateKeySelected(event))
+
+      expect(component.wirelessProfileForm.controls.ieee8021xPrivateKey.value).toBe('data:notbase64-content')
+    } finally {
+      ;(window as unknown as { FileReader: unknown }).FileReader = original
+    }
   })
 })

--- a/src/app/devices/network-settings/network-settings.component.ts
+++ b/src/app/devices/network-settings/network-settings.component.ts
@@ -1,25 +1,75 @@
-import { Component, OnDestroy, OnInit, inject, signal, input } from '@angular/core'
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { Component, OnDestroy, OnInit, inject, signal, input, computed, WritableSignal } from '@angular/core'
+import { HttpErrorResponse } from '@angular/common/http'
 import { DevicesService } from '../devices.service'
 import { MatCardModule } from '@angular/material/card'
-import { catchError, finalize, Subject, takeUntil, throwError } from 'rxjs'
-import { MatSnackBar } from '@angular/material/snack-bar'
+import { catchError, concatMap, finalize, forkJoin, map, of, Subject, takeUntil, throwError } from 'rxjs'
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar'
 import SnackbarDefaults from '../../shared/config/snackBarDefault'
 import { MatListModule } from '@angular/material/list'
 import { MatIcon } from '@angular/material/icon'
-import { MatDivider } from '@angular/material/divider'
 import { MatProgressBarModule } from '@angular/material/progress-bar'
-import { NetworkConfig } from '../../../models/models'
+import { MatTabsModule } from '@angular/material/tabs'
+import {
+  NetworkConfig,
+  WiredNetworkConfigRequest,
+  WirelessState,
+  WirelessStateResponse,
+  DeviceWirelessProfileRequest,
+  DeviceWirelessProfileResponse,
+  DeviceWirelessIEEE8021x,
+  WirelessProfileSyncRequest,
+  WirelessProfileSyncResponse
+} from '../../../models/models'
 import { TranslatePipe, TranslateService } from '@ngx-translate/core'
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators
+} from '@angular/forms'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatInputModule } from '@angular/material/input'
+import { MatSelectModule } from '@angular/material/select'
+import { MatButtonModule } from '@angular/material/button'
+import { MatSlideToggleModule } from '@angular/material/slide-toggle'
+import { MatRadioModule } from '@angular/material/radio'
+import { MatCheckboxModule } from '@angular/material/checkbox'
+import { MatDialog, MatDialogModule } from '@angular/material/dialog'
+import { MatTooltipModule } from '@angular/material/tooltip'
+import { AreYouSureDialogComponent } from '../../shared/are-you-sure/are-you-sure.component'
+import { WifiDisabledAlertComponent } from '../../shared/wifi-disabled-alert/wifi-disabled-alert.component'
+import {
+  NetworkChangeAlertComponent,
+  NetworkChangeAlertData
+} from '../../shared/network-change-alert/network-change-alert.component'
 
 @Component({
   selector: 'app-network-settings',
   imports: [
     MatCardModule,
     MatListModule,
-    MatDivider,
     MatIcon,
     MatProgressBarModule,
-    TranslatePipe
+    TranslatePipe,
+    MatTabsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatSlideToggleModule,
+    MatRadioModule,
+    MatCheckboxModule,
+    MatTooltipModule,
+    ReactiveFormsModule,
+    MatSnackBarModule,
+    MatDialogModule
   ],
   templateUrl: './network-settings.component.html',
   styleUrl: './network-settings.component.scss'
@@ -29,33 +79,848 @@ export class NetworkSettingsComponent implements OnInit, OnDestroy {
   private readonly snackBar = inject(MatSnackBar)
   private readonly devicesService = inject(DevicesService)
   private readonly translate = inject(TranslateService)
+  private readonly fb = inject(FormBuilder)
+  private readonly dialog = inject(MatDialog)
   public readonly deviceId = input('')
   private readonly destroy$ = new Subject<void>()
 
-  public isLoading = signal(true)
-  public networkResults?: NetworkConfig
+  public isWiredLoading = signal(true)
+  public isWirelessLoading = signal(true)
+  public isWirelessConfigLoading = signal(true)
+  public selectedTabIndex = signal(0)
+  public isSavingWired = signal(false)
+  public isSavingWireless = signal(false)
+  public isSavingWirelessProfile = signal(false)
+  public isLoadingWirelessProfiles = signal(false)
+  public isRefreshingNetwork = signal(false)
+  public uefiProfileSyncSupported = signal(true)
+  public wiredIeee8021xExpanded = signal(false)
+  public networkResults = signal<NetworkConfig | undefined>(undefined)
+  public wirelessStatus = signal<
+    | {
+        enabled: boolean
+        localProfileSyncEnabled: boolean
+        uefiProfileSyncEnabled: boolean
+      }
+    | undefined
+  >(undefined)
+  public wirelessProfiles = signal<DeviceWirelessProfileResponse[]>([])
+  public readonly maxWirelessProfiles = 8
+  public readonly isWirelessProfileLimitReached = computed(
+    () => this.wirelessProfiles().length >= this.maxWirelessProfiles
+  )
+  public editingWirelessProfileName = signal<string | null>(null)
+  public showWirelessProfileForm = signal(false)
+  public showWiredConfigForm = signal(false)
+  public showWirelessConfigForm = signal(false)
+  public clientCertFileName = signal('')
+  public privateKeyFileName = signal('')
+  public caCertFileName = signal('')
+  public readonly wirelessAuthMethodOptions = [
+    'WPAPSK',
+    'WPA2PSK',
+    'WPAIEEE8021x',
+    'WPA2IEEE8021x'
+  ]
+
+  public readonly wirelessEncryptionMethodOptions = [
+    'TKIP',
+    'CCMP'
+  ]
+
+  public readonly wirelessIEEE8021xProtocolOptions = [
+    { value: 0, label: 'EAP-TLS' },
+    { value: 2, label: 'PEAP-MSCHAPv2' }
+  ]
+
+  public readonly ieee8021xProtocolTLS = 0
+  public readonly ieee8021xProtocolPEAP = 2
+
+  public readonly wiredForm = this.fb.nonNullable.group({
+    dhcpEnabled: true,
+    ipSyncEnabled: true,
+    ipAddress: '',
+    subnetMask: '',
+    defaultGateway: '',
+    primaryDNS: '',
+    secondaryDNS: ''
+  })
+
+  public readonly wirelessSettingsForm = this.fb.nonNullable.group({
+    enabled: true,
+    localProfileSyncEnabled: false,
+    uefiProfileSyncEnabled: false
+  })
+
+  public readonly wirelessProfileForm = this.fb.nonNullable.group({
+    profileName: ['', [Validators.required, Validators.pattern(/^[a-zA-Z0-9]+$/)]],
+    ssid: ['', Validators.required],
+    priority: [
+      null as number | null,
+      [
+        Validators.required,
+        Validators.min(1),
+        Validators.max(255),
+        this.priorityConflictValidator()
+      ]
+    ],
+    authenticationMethod: ['WPA2PSK', Validators.required],
+    encryptionMethod: ['CCMP', Validators.required],
+    password: [''],
+    ieee8021xUsername: [''],
+    ieee8021xAuthenticationProtocol: [0],
+    ieee8021xPassword: [''],
+    ieee8021xClientCert: [''],
+    ieee8021xPrivateKey: [''],
+    ieee8021xCACert: ['']
+  })
 
   ngOnInit(): void {
+    this.setupWiredFormBehavior()
+
     this.devicesService
       .getNetworkSettings(this.deviceId())
       .pipe(
         catchError((err) => {
           const msg: string = this.translate.instant('network.errorNetworkSetting.value')
           this.snackBar.open(msg, undefined, SnackbarDefaults.defaultError)
-          return throwError(err)
+          this.isWirelessConfigLoading.set(false)
+          return throwError(() => err)
         }),
         finalize(() => {
-          this.isLoading.set(false)
+          this.isWiredLoading.set(false)
+          this.isWirelessLoading.set(false)
         })
       )
       .pipe(takeUntil(this.destroy$))
       .subscribe((results) => {
-        this.networkResults = results
+        this.networkResults.set(results)
+        this.patchWiredForm(results)
+        if (results?.wired == null && results?.wireless != null) {
+          this.selectedTabIndex.set(1)
+        }
+        if (results?.wireless != null) {
+          this.loadWirelessCardData()
+        } else {
+          this.isWirelessConfigLoading.set(false)
+        }
       })
+
+    this.wirelessProfileForm.controls.authenticationMethod.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.updateWirelessProfileValidators()
+    })
+    this.wirelessProfileForm.controls.ieee8021xAuthenticationProtocol.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.updateWirelessProfileValidators()
+      })
+    this.updateWirelessProfileValidators()
   }
 
   ngOnDestroy(): void {
     this.destroy$.next()
     this.destroy$.complete()
+  }
+
+  public hasWiredAdapter(): boolean {
+    return this.isWiredLoading() || this.networkResults()?.wired != null
+  }
+
+  public hasWirelessAdapter(): boolean {
+    return this.isWirelessLoading() || this.networkResults()?.wireless != null
+  }
+
+  public isWiredIeee8021xEnabled(): boolean {
+    const enabled = this.networkResults()?.wired?.ieee8021x?.enabled
+    return enabled != null && enabled !== '' && enabled !== 'Disabled'
+  }
+
+  public toggleWiredIeee8021x(): void {
+    this.wiredIeee8021xExpanded.update((expanded) => !expanded)
+  }
+
+  public toggleWiredConfigForm(): void {
+    this.showWiredConfigForm.update((shown) => !shown)
+  }
+
+  public toggleWirelessConfigForm(): void {
+    this.showWirelessConfigForm.update((shown) => !shown)
+  }
+
+  // Reverts the wired settings form to the values last reported by the device, clears any pending
+  // edits (so the Save button greys out again) and hides the form.
+  public cancelWiredSettings(): void {
+    const results = this.networkResults()
+    if (results != null) {
+      this.patchWiredForm(results)
+    }
+    this.wiredForm.markAsPristine()
+    this.showWiredConfigForm.set(false)
+  }
+
+  // Reverts the wireless settings form to the values last reported by the device, clears any pending
+  // edits (so the Save button greys out again) and hides the form.
+  public cancelWirelessSettings(): void {
+    const status = this.wirelessStatus()
+    if (status != null) {
+      this.wirelessSettingsForm.patchValue(
+        {
+          enabled: status.enabled,
+          localProfileSyncEnabled: status.localProfileSyncEnabled,
+          uefiProfileSyncEnabled: status.uefiProfileSyncEnabled
+        },
+        { emitEvent: false }
+      )
+    }
+    this.wirelessSettingsForm.markAsPristine()
+    this.showWirelessConfigForm.set(false)
+  }
+
+  // Toggles the "Add Profile" form. Opening routes through addNewWirelessProfile so the
+  // WiFi-disabled warning still fires; closing simply resets the form with no dialog.
+  public toggleWirelessProfileForm(): void {
+    if (this.showWirelessProfileForm() && this.editingWirelessProfileName() == null) {
+      this.resetWirelessProfileForm()
+      return
+    }
+    this.addNewWirelessProfile()
+  }
+
+  // Opens a confirmation dialog warning that saving may interrupt the device's connectivity and
+  // emits the user's decision (true to proceed). The warning text is chosen by the caller so it
+  // can match the specific change being saved.
+  private confirmNetworkChange(messageKey: string) {
+    const data: NetworkChangeAlertData = { messageKey }
+    return this.dialog.open(NetworkChangeAlertComponent, { data }).afterClosed().pipe(takeUntil(this.destroy$))
+  }
+
+  public saveWiredSettings(): void {
+    if (this.wiredForm.invalid) {
+      this.wiredForm.markAllAsTouched()
+      return
+    }
+
+    // Applying wired settings can interrupt the device's connectivity, so confirm with the user
+    // first.
+    this.confirmNetworkChange('network.changeAlert.message.value').subscribe((confirmed) => {
+      if (confirmed === true) {
+        this.applyWiredSettings()
+      }
+    })
+  }
+
+  private applyWiredSettings(): void {
+    const raw = this.wiredForm.getRawValue()
+    const payload: WiredNetworkConfigRequest = {
+      dhcpEnabled: raw.dhcpEnabled,
+      ipSyncEnabled: raw.ipSyncEnabled
+    }
+
+    if (!raw.dhcpEnabled && !raw.ipSyncEnabled) {
+      payload.ipAddress = raw.ipAddress
+      payload.subnetMask = raw.subnetMask
+      payload.defaultGateway = raw.defaultGateway
+      payload.primaryDNS = raw.primaryDNS
+      payload.secondaryDNS = raw.secondaryDNS
+    }
+
+    this.isSavingWired.set(true)
+    this.devicesService
+      .patchWiredNetworkSettings(this.deviceId(), payload)
+      .pipe(
+        catchError((err) => {
+          this.showError(this.translate.instant('network.wired.updateError.value'), err)
+          return throwError(() => err)
+        }),
+        finalize(() => {
+          this.isSavingWired.set(false)
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.snackBar.open(
+          this.translate.instant('network.wired.updateSuccess.value'),
+          undefined,
+          SnackbarDefaults.defaultSuccess
+        )
+        this.wiredForm.markAsPristine()
+        this.refreshNetworkSettings()
+      })
+  }
+
+  public saveWirelessSettings(): void {
+    // Changing the wireless state can interrupt the device's connectivity, so confirm with the
+    // user first. Disabling WiFi gets a stronger warning since it permanently drops any wireless
+    // connection: with no wired adapter there is no way back, and with one the user must already
+    // have wired access to avoid losing the device entirely.
+    let messageKey = 'network.changeAlert.message.value'
+    if (!this.wirelessSettingsForm.controls.enabled.value) {
+      messageKey = this.hasWiredAdapter()
+        ? 'network.changeAlert.wifiDisableWithWired.value'
+        : 'network.changeAlert.wifiDisableNoWired.value'
+    }
+
+    this.confirmNetworkChange(messageKey).subscribe((confirmed) => {
+      if (confirmed === true) {
+        this.applyWirelessSettings()
+      }
+    })
+  }
+
+  private applyWirelessSettings(): void {
+    const raw = this.wirelessSettingsForm.getRawValue()
+    const statePayload = {
+      state: raw.enabled ? ('WifiEnabledS0SxAC' as WirelessState) : ('WifiDisabled' as WirelessState)
+    }
+    const syncPayload: WirelessProfileSyncRequest = {
+      localProfileSync: raw.localProfileSyncEnabled,
+      uefiProfileSync: raw.uefiProfileSyncEnabled
+    }
+    this.isSavingWireless.set(true)
+    this.wirelessSettingsForm.disable({ emitEvent: false })
+
+    // Apply the wireless state change first, then the profile sync settings sequentially. The local
+    // and UEFI sync settings live on the same WiFiPortConfigurationService object and each backend
+    // call performs a read-modify-write, so they must run in order to avoid clobbering each other.
+    this.devicesService
+      .requestWirelessStateChange(this.deviceId(), statePayload)
+      .pipe(
+        concatMap((state) =>
+          this.devicesService
+            .setWirelessProfileSync(this.deviceId(), syncPayload)
+            .pipe(map((sync) => ({ state, sync })))
+        ),
+        catchError((err) => {
+          this.showError(this.translate.instant('network.wireless.updateError.value'), err)
+          this.loadWirelessConfiguration()
+          return throwError(() => err)
+        }),
+        finalize(() => {
+          this.isSavingWireless.set(false)
+          this.wirelessSettingsForm.enable({ emitEvent: false })
+          this.applyUefiProfileSyncSupport(this.uefiProfileSyncSupported())
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((rsp) => {
+        this.wirelessSettingsForm.patchValue({
+          enabled: rsp.state.state !== 'WifiDisabled',
+          localProfileSyncEnabled: rsp.sync.localProfileSync,
+          uefiProfileSyncEnabled: rsp.sync.uefiProfileSync
+        })
+        this.uefiProfileSyncSupported.set(rsp.sync.uefiProfileSyncSupported)
+        this.updateWirelessStatus(rsp.state, rsp.sync)
+        this.wirelessSettingsForm.markAsPristine()
+        this.snackBar.open(
+          this.translate.instant('network.wireless.updateSuccess.value'),
+          undefined,
+          SnackbarDefaults.defaultSuccess
+        )
+        this.refreshNetworkSettings()
+      })
+  }
+
+  public saveWirelessProfile(): void {
+    if (this.wirelessProfileForm.invalid) {
+      this.wirelessProfileForm.markAllAsTouched()
+      return
+    }
+
+    const raw = this.wirelessProfileForm.getRawValue()
+    const payload: DeviceWirelessProfileRequest = {
+      profileName: raw.profileName,
+      ssid: raw.ssid,
+      priority: Number(raw.priority),
+      authenticationMethod: raw.authenticationMethod,
+      encryptionMethod: raw.encryptionMethod
+    }
+
+    if (this.requiresPskPassword(raw.authenticationMethod)) {
+      payload.password = raw.password
+    } else {
+      const ieee8021x: DeviceWirelessIEEE8021x = {
+        username: raw.ieee8021xUsername,
+        authenticationProtocol: raw.ieee8021xAuthenticationProtocol
+      }
+
+      if (raw.ieee8021xAuthenticationProtocol === this.ieee8021xProtocolPEAP) {
+        ieee8021x.password = raw.ieee8021xPassword
+      }
+
+      if (raw.ieee8021xAuthenticationProtocol === this.ieee8021xProtocolTLS) {
+        ieee8021x.clientCert = raw.ieee8021xClientCert
+        ieee8021x.privateKey = raw.ieee8021xPrivateKey
+      }
+
+      if (raw.ieee8021xCACert !== '') {
+        ieee8021x.caCert = raw.ieee8021xCACert
+      }
+
+      payload.ieee8021x = ieee8021x
+    }
+
+    this.isSavingWirelessProfile.set(true)
+    const request =
+      this.editingWirelessProfileName() == null
+        ? this.devicesService.addWirelessProfile(this.deviceId(), payload)
+        : this.devicesService.updateWirelessProfile(this.deviceId(), payload)
+
+    request
+      .pipe(
+        catchError((err) => {
+          this.showError(this.translate.instant('network.wirelessProfile.saveError.value'), err)
+          return throwError(() => err)
+        }),
+        finalize(() => {
+          this.isSavingWirelessProfile.set(false)
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.snackBar.open(
+          this.translate.instant('network.wirelessProfile.saveSuccess.value'),
+          undefined,
+          SnackbarDefaults.defaultSuccess
+        )
+        this.resetWirelessProfileForm()
+        this.loadWirelessProfiles()
+      })
+  }
+
+  public addNewWirelessProfile(): void {
+    if (!this.wirelessStatus()?.enabled) {
+      this.dialog
+        .open(WifiDisabledAlertComponent)
+        .afterClosed()
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.resetWirelessProfileForm()
+          this.showWirelessProfileForm.set(true)
+        })
+      return
+    }
+    this.resetWirelessProfileForm()
+    this.showWirelessProfileForm.set(true)
+  }
+
+  public editWirelessProfile(profile: DeviceWirelessProfileResponse): void {
+    this.editingWirelessProfileName.set(profile.profileName)
+    this.showWirelessProfileForm.set(true)
+    this.clientCertFileName.set('')
+    this.privateKeyFileName.set('')
+    this.caCertFileName.set('')
+    this.wirelessProfileForm.controls.profileName.disable({ emitEvent: false })
+    this.wirelessProfileForm.patchValue(
+      {
+        profileName: profile.profileName,
+        ssid: profile.ssid,
+        priority: profile.priority,
+        authenticationMethod: profile.authenticationMethod,
+        encryptionMethod: profile.encryptionMethod,
+        password: '',
+        ieee8021xUsername: profile.ieee8021x?.username ?? '',
+        ieee8021xAuthenticationProtocol: profile.ieee8021x?.authenticationProtocol ?? 0,
+        ieee8021xPassword: '',
+        ieee8021xClientCert: '',
+        ieee8021xPrivateKey: '',
+        ieee8021xCACert: ''
+      },
+      { emitEvent: false }
+    )
+    this.wirelessProfileForm.controls.priority.updateValueAndValidity({ emitEvent: false })
+    this.updateWirelessProfileValidators()
+  }
+
+  public resetWirelessProfileForm(): void {
+    this.editingWirelessProfileName.set(null)
+    this.showWirelessProfileForm.set(false)
+    this.clientCertFileName.set('')
+    this.privateKeyFileName.set('')
+    this.caCertFileName.set('')
+    this.wirelessProfileForm.controls.profileName.enable({ emitEvent: false })
+    this.wirelessProfileForm.reset({
+      profileName: '',
+      ssid: '',
+      priority: null,
+      authenticationMethod: 'WPA2PSK',
+      encryptionMethod: 'CCMP',
+      password: '',
+      ieee8021xUsername: '',
+      ieee8021xAuthenticationProtocol: 0,
+      ieee8021xPassword: '',
+      ieee8021xClientCert: '',
+      ieee8021xPrivateKey: '',
+      ieee8021xCACert: ''
+    })
+    this.updateWirelessProfileValidators()
+  }
+
+  public deleteWirelessProfile(profileName: string): void {
+    const dialogRef = this.dialog.open(AreYouSureDialogComponent)
+
+    dialogRef
+      .afterClosed()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((confirmed) => {
+        if (confirmed !== true) {
+          return
+        }
+
+        this.isSavingWirelessProfile.set(true)
+        this.devicesService
+          .deleteWirelessProfile(this.deviceId(), profileName)
+          .pipe(
+            catchError((err) => {
+              this.showError(this.translate.instant('network.wirelessProfile.deleteError.value'), err)
+              return throwError(() => err)
+            }),
+            finalize(() => {
+              this.isSavingWirelessProfile.set(false)
+            }),
+            takeUntil(this.destroy$)
+          )
+          .subscribe(() => {
+            this.snackBar.open(
+              this.translate.instant('network.wirelessProfile.deleteSuccess.value'),
+              undefined,
+              SnackbarDefaults.defaultSuccess
+            )
+            if (this.editingWirelessProfileName() === profileName) {
+              this.resetWirelessProfileForm()
+            }
+            this.loadWirelessProfiles()
+          })
+      })
+  }
+
+  private refreshNetworkSettings(): void {
+    this.isRefreshingNetwork.set(true)
+    this.devicesService
+      .getNetworkSettings(this.deviceId())
+      .pipe(
+        catchError(() => of(null)),
+        finalize(() => {
+          this.isRefreshingNetwork.set(false)
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((results) => {
+        if (results == null) {
+          return
+        }
+        this.networkResults.set(results)
+        this.patchWiredForm(results)
+      })
+  }
+
+  private patchWiredForm(results: NetworkConfig): void {
+    const wired = results?.wired
+    if (wired == null) {
+      return
+    }
+
+    this.wiredForm.patchValue(
+      {
+        dhcpEnabled: wired.dhcpEnabled,
+        ipSyncEnabled: wired.dhcpEnabled ? true : wired.ipSyncEnabled,
+        ipAddress: wired.ipAddress ?? '',
+        subnetMask: wired.subnetMask ?? '',
+        defaultGateway: wired.defaultGateway ?? '',
+        primaryDNS: wired.primaryDNS ?? '',
+        secondaryDNS: wired.secondaryDNS ?? ''
+      },
+      { emitEvent: false }
+    )
+
+    if (wired.dhcpEnabled) {
+      this.wiredForm.controls.ipSyncEnabled.disable({ emitEvent: false })
+    } else {
+      this.wiredForm.controls.ipSyncEnabled.enable({ emitEvent: false })
+    }
+
+    this.updateWiredStaticValidators()
+  }
+
+  private loadWirelessCardData(): void {
+    this.isWirelessConfigLoading.set(true)
+    forkJoin({
+      state: this.devicesService.getWirelessState(this.deviceId()).pipe(catchError(() => of(null))),
+      profileSync: this.devicesService.getWirelessProfileSync(this.deviceId()).pipe(catchError(() => of(null))),
+      profiles: this.devicesService
+        .getWirelessProfiles(this.deviceId())
+        .pipe(catchError(() => of([] as DeviceWirelessProfileResponse[])))
+    })
+      .pipe(
+        finalize(() => {
+          this.isWirelessConfigLoading.set(false)
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((rsp) => {
+        this.patchWirelessSettingsForm(rsp.state, rsp.profileSync)
+        this.wirelessProfiles.set(this.sortProfilesByPriority(rsp.profiles))
+        this.wirelessProfileForm.controls.priority.updateValueAndValidity({ emitEvent: false })
+      })
+  }
+
+  private loadWirelessConfiguration(): void {
+    forkJoin({
+      state: this.devicesService.getWirelessState(this.deviceId()).pipe(catchError(() => of(null))),
+      profileSync: this.devicesService.getWirelessProfileSync(this.deviceId()).pipe(catchError(() => of(null)))
+    })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((rsp) => {
+        this.patchWirelessSettingsForm(rsp.state, rsp.profileSync)
+      })
+  }
+
+  // Patches the wireless settings form and dependent status from a state/profile-sync pair.
+  // When a particular response is unavailable (null) the form's current value is retained so a
+  // partial refresh does not blank out a setting.
+  private patchWirelessSettingsForm(
+    state: WirelessStateResponse | null,
+    profileSync: WirelessProfileSyncResponse | null
+  ): void {
+    const controls = this.wirelessSettingsForm.controls
+    this.wirelessSettingsForm.patchValue({
+      enabled: state != null ? state.state !== 'WifiDisabled' : controls.enabled.value,
+      localProfileSyncEnabled: profileSync?.localProfileSync ?? controls.localProfileSyncEnabled.value,
+      uefiProfileSyncEnabled: profileSync?.uefiProfileSync ?? controls.uefiProfileSyncEnabled.value
+    })
+    this.applyUefiProfileSyncSupport(profileSync?.uefiProfileSyncSupported ?? true)
+    this.updateWirelessStatus(state, profileSync)
+  }
+
+  // The UEFI/CSME Wi-Fi profile sharing setting is only available on devices whose
+  // firmware reports support for it. When unsupported, force the toggle off and disable
+  // it so the user cannot submit a change the backend would reject.
+  private applyUefiProfileSyncSupport(supported: boolean): void {
+    this.uefiProfileSyncSupported.set(supported)
+    const control = this.wirelessSettingsForm.controls.uefiProfileSyncEnabled
+    if (supported) {
+      control.enable({ emitEvent: false })
+    } else {
+      control.setValue(false, { emitEvent: false })
+      control.disable({ emitEvent: false })
+    }
+  }
+
+  // Captures the wireless status reported by the device into the read-only snapshot signal.
+  // When a particular response is unavailable (null) the previously known value is retained so a
+  // partial refresh does not blank out the displayed status.
+  private updateWirelessStatus(
+    state: WirelessStateResponse | null,
+    profileSync: WirelessProfileSyncResponse | null
+  ): void {
+    const current = this.wirelessStatus()
+    this.wirelessStatus.set({
+      enabled: state != null ? state.state !== 'WifiDisabled' : (current?.enabled ?? false),
+      localProfileSyncEnabled: profileSync?.localProfileSync ?? current?.localProfileSyncEnabled ?? false,
+      uefiProfileSyncEnabled: profileSync?.uefiProfileSync ?? current?.uefiProfileSyncEnabled ?? false
+    })
+  }
+
+  private loadWirelessProfiles(): void {
+    this.isLoadingWirelessProfiles.set(true)
+    this.devicesService
+      .getWirelessProfiles(this.deviceId())
+      .pipe(
+        catchError(() => of([])),
+        finalize(() => {
+          this.isLoadingWirelessProfiles.set(false)
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((profiles) => {
+        this.wirelessProfiles.set(this.sortProfilesByPriority(profiles))
+        this.wirelessProfileForm.controls.priority.updateValueAndValidity({ emitEvent: false })
+      })
+  }
+
+  private sortProfilesByPriority(profiles: DeviceWirelessProfileResponse[]): DeviceWirelessProfileResponse[] {
+    return [...profiles].sort((a, b) => a.priority - b.priority)
+  }
+
+  // Prevents non-numeric characters (e, E, +, -, .) that the native number
+  // input would otherwise accept while typing into the priority field.
+  public blockNonNumericKey(event: KeyboardEvent): void {
+    if ([
+        'e',
+        'E',
+        '+',
+        '-',
+        '.'
+      ].includes(event.key)) {
+      event.preventDefault()
+    }
+  }
+
+  // Rejects a priority that is already used by another wireless profile on the
+  // device. The profile currently being edited is excluded so re-saving it with
+  // its own priority does not flag a conflict.
+  private priorityConflictValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const value = control.value
+      if (value == null || value === '') {
+        return null
+      }
+
+      const editingName = this.editingWirelessProfileName()
+      const hasConflict = this.wirelessProfiles().some(
+        (profile) => profile.priority === Number(value) && profile.profileName !== editingName
+      )
+
+      return hasConflict ? { priorityConflict: true } : null
+    }
+  }
+
+  private setupWiredFormBehavior(): void {
+    this.wiredForm.controls.dhcpEnabled.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((isDhcpEnabled) => {
+      if (isDhcpEnabled) {
+        this.wiredForm.controls.ipSyncEnabled.patchValue(true, { emitEvent: false })
+        this.wiredForm.controls.ipSyncEnabled.disable({ emitEvent: false })
+      } else {
+        this.wiredForm.controls.ipSyncEnabled.enable({ emitEvent: false })
+      }
+
+      this.updateWiredStaticValidators()
+    })
+
+    this.wiredForm.controls.ipSyncEnabled.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.updateWiredStaticValidators()
+    })
+
+    if (this.wiredForm.controls.dhcpEnabled.value) {
+      this.wiredForm.controls.ipSyncEnabled.disable({ emitEvent: false })
+    }
+  }
+
+  private updateWiredStaticValidators(): void {
+    const requiresStaticValues =
+      !this.wiredForm.controls.dhcpEnabled.value && !this.wiredForm.controls.ipSyncEnabled.value
+    const controls = [
+      this.wiredForm.controls.ipAddress,
+      this.wiredForm.controls.subnetMask,
+      this.wiredForm.controls.defaultGateway,
+      this.wiredForm.controls.primaryDNS
+    ]
+
+    controls.forEach((control) => {
+      if (requiresStaticValues) {
+        control.setValidators([Validators.required])
+      } else {
+        control.clearValidators()
+      }
+      control.updateValueAndValidity({ emitEvent: false })
+    })
+  }
+
+  private updateWirelessProfileValidators(): void {
+    const authMethod = this.wirelessProfileForm.controls.authenticationMethod.value
+    const isPSK = this.requiresPskPassword(authMethod)
+    const protocol = this.wirelessProfileForm.controls.ieee8021xAuthenticationProtocol.value
+    const controls = this.wirelessProfileForm.controls
+
+    if (isPSK) {
+      controls.password.setValidators([Validators.required, Validators.minLength(8)])
+      controls.ieee8021xUsername.clearValidators()
+      controls.ieee8021xPassword.clearValidators()
+      controls.ieee8021xClientCert.clearValidators()
+      controls.ieee8021xPrivateKey.clearValidators()
+    } else {
+      controls.password.clearValidators()
+      controls.ieee8021xUsername.setValidators([Validators.required])
+
+      if (protocol === this.ieee8021xProtocolPEAP) {
+        controls.ieee8021xPassword.setValidators([Validators.required])
+        controls.ieee8021xClientCert.clearValidators()
+        controls.ieee8021xPrivateKey.clearValidators()
+      } else {
+        controls.ieee8021xPassword.clearValidators()
+        controls.ieee8021xClientCert.setValidators([Validators.required])
+        controls.ieee8021xPrivateKey.setValidators([Validators.required])
+      }
+    }
+
+    controls.password.updateValueAndValidity({ emitEvent: false })
+    controls.ieee8021xUsername.updateValueAndValidity({ emitEvent: false })
+    controls.ieee8021xPassword.updateValueAndValidity({ emitEvent: false })
+    controls.ieee8021xClientCert.updateValueAndValidity({ emitEvent: false })
+    controls.ieee8021xPrivateKey.updateValueAndValidity({ emitEvent: false })
+  }
+
+  private requiresPskPassword(authenticationMethod: string): boolean {
+    return authenticationMethod === 'WPAPSK' || authenticationMethod === 'WPA2PSK'
+  }
+
+  public onClientCertSelected(event: Event): void {
+    this.readCredentialFile(event, 'ieee8021xClientCert', this.clientCertFileName)
+  }
+
+  public onPrivateKeySelected(event: Event): void {
+    this.readCredentialFile(event, 'ieee8021xPrivateKey', this.privateKeyFileName)
+  }
+
+  public onCACertSelected(event: Event): void {
+    this.readCredentialFile(event, 'ieee8021xCACert', this.caCertFileName)
+  }
+
+  // Reads a certificate or key file and stores its base64 DER body (PEM armor and
+  // whitespace stripped) in the given form control, matching the format the backend
+  // expects when adding credentials to the device.
+  private readCredentialFile(
+    event: Event,
+    controlName: 'ieee8021xClientCert' | 'ieee8021xPrivateKey' | 'ieee8021xCACert',
+    fileNameSignal: WritableSignal<string>
+  ): void {
+    if (typeof FileReader === 'undefined') {
+      return
+    }
+
+    const target = event.target as HTMLInputElement | null
+    const files = target?.files
+    if (files == null || files.length === 0) {
+      return
+    }
+
+    const file = files[0]
+    const isPem = /\.(pem|key|crt|cer)$/i.test(file.name)
+    const reader = new FileReader()
+
+    reader.onload = (e: ProgressEvent<FileReader>) => {
+      const result = e.target?.result as string
+      let credential: string
+      if (isPem) {
+        credential = result.replace(/-----(BEGIN|END)[^-]+-----/g, '').replace(/\s+/g, '')
+      } else {
+        const index = result.indexOf('base64,')
+        credential = index >= 0 ? result.substring(index + 7) : result
+      }
+
+      this.wirelessProfileForm.controls[controlName].setValue(credential)
+      this.wirelessProfileForm.controls[controlName].markAsDirty()
+      fileNameSignal.set(file.name)
+    }
+
+    if (isPem) {
+      reader.readAsText(file)
+    } else {
+      reader.readAsDataURL(file)
+    }
+
+    // Allow re-selecting the same file by clearing the native input value.
+    if (target != null) {
+      target.value = ''
+    }
+  }
+
+  private showError(message: string, err?: unknown): void {
+    // The global error-handling interceptor already surfaces a dialog for stale-write
+    // conflicts (409/412). Suppress the local snackbar for those so the user does not
+    // see two competing messages for the same failure.
+    if (err instanceof HttpErrorResponse && (err.status === 409 || err.status === 412)) {
+      return
+    }
+    this.snackBar.open(message, undefined, SnackbarDefaults.defaultError)
   }
 }

--- a/src/app/shared/network-change-alert/network-change-alert.component.html
+++ b/src/app/shared/network-change-alert/network-change-alert.component.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title>{{ 'network.changeAlert.title.value' | translate }}</h2>
+<mat-dialog-content class="mat-typography">{{ data.messageKey | translate }}</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button data-cy="network-change-cancel" mat-dialog-close>
+    {{ 'common.cancelLower.value' | translate }}
+  </button>
+  <button mat-button data-cy="network-change-continue" [mat-dialog-close]="true" cdkFocusInitial>
+    {{ 'common.continue.value' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/shared/network-change-alert/network-change-alert.component.spec.ts
+++ b/src/app/shared/network-change-alert/network-change-alert.component.spec.ts
@@ -1,0 +1,46 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog'
+
+import { NetworkChangeAlertComponent } from './network-change-alert.component'
+import { provideTranslateService } from '@ngx-translate/core'
+
+describe('NetworkChangeAlertComponent', () => {
+  let component: NetworkChangeAlertComponent
+  let fixture: ComponentFixture<NetworkChangeAlertComponent>
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MatDialogModule,
+        NetworkChangeAlertComponent
+      ],
+      providers: [
+        provideTranslateService(),
+        { provide: MAT_DIALOG_DATA, useValue: { messageKey: 'network.changeAlert.message.value' } }
+      ]
+    })
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NetworkChangeAlertComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  afterEach(() => {
+    TestBed.resetTestingModule()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('exposes the injected message key', () => {
+    expect(component.data.messageKey).toBe('network.changeAlert.message.value')
+  })
+})

--- a/src/app/shared/network-change-alert/network-change-alert.component.ts
+++ b/src/app/shared/network-change-alert/network-change-alert.component.ts
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { Component, inject } from '@angular/core'
+import { MatButton } from '@angular/material/button'
+import { CdkScrollable } from '@angular/cdk/scrolling'
+import {
+  MAT_DIALOG_DATA,
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogClose
+} from '@angular/material/dialog'
+import { TranslatePipe } from '@ngx-translate/core'
+
+// Data passed to the dialog. messageKey is a translation key (including the `.value`
+// suffix) so the caller can pick the warning that matches the change being saved.
+export interface NetworkChangeAlertData {
+  messageKey: string
+}
+
+@Component({
+  selector: 'app-network-change-alert',
+  templateUrl: './network-change-alert.component.html',
+  styleUrls: ['./network-change-alert.component.scss'],
+  imports: [
+    MatDialogTitle,
+    CdkScrollable,
+    MatDialogContent,
+    MatDialogActions,
+    MatButton,
+    MatDialogClose,
+    TranslatePipe
+  ]
+})
+export class NetworkChangeAlertComponent {
+  public readonly data = inject<NetworkChangeAlertData>(MAT_DIALOG_DATA)
+}

--- a/src/app/shared/wifi-disabled-alert/wifi-disabled-alert.component.html
+++ b/src/app/shared/wifi-disabled-alert/wifi-disabled-alert.component.html
@@ -1,0 +1,9 @@
+<h2 mat-dialog-title>{{ 'network.wirelessProfile.wifiDisabledAlertTitle.value' | translate }}</h2>
+<mat-dialog-content class="mat-typography">{{
+  'network.wirelessProfile.wifiDisabledAlert.value' | translate
+}}</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button data-cy="wifi-disabled-alert-ok" [mat-dialog-close]="true" cdkFocusInitial>
+    {{ 'common.ok.value' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/shared/wifi-disabled-alert/wifi-disabled-alert.component.spec.ts
+++ b/src/app/shared/wifi-disabled-alert/wifi-disabled-alert.component.spec.ts
@@ -1,0 +1,39 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { MatDialogModule } from '@angular/material/dialog'
+
+import { WifiDisabledAlertComponent } from './wifi-disabled-alert.component'
+import { provideTranslateService } from '@ngx-translate/core'
+
+describe('WifiDisabledAlertComponent', () => {
+  let component: WifiDisabledAlertComponent
+  let fixture: ComponentFixture<WifiDisabledAlertComponent>
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MatDialogModule,
+        WifiDisabledAlertComponent
+      ],
+      providers: [provideTranslateService()]
+    })
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WifiDisabledAlertComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  afterEach(() => {
+    TestBed.resetTestingModule()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/wifi-disabled-alert/wifi-disabled-alert.component.ts
+++ b/src/app/shared/wifi-disabled-alert/wifi-disabled-alert.component.ts
@@ -1,0 +1,26 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { Component } from '@angular/core'
+import { MatButton } from '@angular/material/button'
+import { CdkScrollable } from '@angular/cdk/scrolling'
+import { MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog'
+import { TranslatePipe } from '@ngx-translate/core'
+
+@Component({
+  selector: 'app-wifi-disabled-alert',
+  templateUrl: './wifi-disabled-alert.component.html',
+  styleUrls: ['./wifi-disabled-alert.component.scss'],
+  imports: [
+    MatDialogTitle,
+    CdkScrollable,
+    MatDialogContent,
+    MatDialogActions,
+    MatButton,
+    TranslatePipe,
+    MatDialogClose
+  ]
+})
+export class WifiDisabledAlertComponent {}

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "تسمية لمزامنة الملفات الشخصية المحلية اللاسلكية",
-    "value": "مزامنة الملف الشخصي المحلي"
+    "value": "مزامنة ملفات تعريف Wi-Fi في نظام التشغيل"
   },
   "network.wireless.macAddress": {
     "description": "تسمية عنوان MAC اللاسلكي",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Bezeichnung für die drahtlose lokale Profilsynchronisierung",
-    "value": "Lokale Profilsynchronisierung"
+    "value": "Synchronisierung von OS-Wi-Fi-Profilen"
   },
   "network.wireless.macAddress": {
     "description": "Bezeichnung für drahtlose MAC-Adresse",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -139,6 +139,14 @@
     "value": "SAVE",
     "description": "Save button text"
   },
+  "common.edit": {
+    "value": "Edit",
+    "description": "Edit button text"
+  },
+  "common.editSettings": {
+    "value": "Edit Settings",
+    "description": "Edit settings button text"
+  },
   "common.update": {
     "value": "UPDATE",
     "description": "Update button text"
@@ -1027,7 +1035,7 @@
   },
   "deviceDetail.networkSettingsDescription": {
     "description": "Description for network settings",
-    "value": "View network settings"
+    "value": "Manage network settings"
   },
   "deviceDetail.noEventLog": {
     "description": "Category name for no event logs",
@@ -1995,6 +2003,14 @@
     "description": "Table header for MQTT event type",
     "value": "Type"
   },
+  "network.disabled": {
+    "description": "Used when a network setting is disabled",
+    "value": "Disabled"
+  },
+  "network.enabled": {
+    "description": "Used when a network setting is enabled",
+    "value": "Enabled"
+  },
   "network.errorNetworkSetting": {
     "description": "Error for retrieving network settings",
     "value": "Error retrieving network settings"
@@ -2047,6 +2063,10 @@
     "description": "Label for IEEE 8021x wireless server certificate name",
     "value": "Server Certificate Name"
   },
+  "network.ieee.status": {
+    "description": "Label for the 802.1x authentication section in the network status card",
+    "value": "802.1x Authentication"
+  },
   "network.ieee.subtitle": {
     "description": "Subtitle for the IEEE 8021x network settings card",
     "value": "View IEEE 8021x network settings for this device"
@@ -2074,6 +2094,10 @@
   "network.wired.ipSyncEnabled": {
     "description": "Label for wired IP sync enabled status",
     "value": "IP Sync Enabled"
+  },
+  "network.wired.ipSyncHintEnabled": {
+    "description": "Hint for wired IP sync when enabled on the network settings page",
+    "value": "Requires LMS to perform synchronization"
   },
   "network.wired.linkControl": {
     "description": "Label for wired link control",
@@ -2115,17 +2139,61 @@
     "description": "Label for wired shared static IP",
     "value": "Shared Static IP"
   },
+  "network.wired.sharedIP": {
+    "description": "Label for the derived wired shared IP status",
+    "value": "Shared IP"
+  },
   "network.wired.subnetMask": {
     "description": "Label for the wired subnet mask",
     "value": "Subnet Mask"
   },
   "network.wired.subtitle": {
     "description": "Subtitle for the wired network settings card",
-    "value": "View wired network settings for this device"
+    "value": "View or configure wired network settings for this device"
   },
   "network.wired.title": {
     "description": "Title of the wired network settings card",
     "value": "Wired Network Settings"
+  },
+  "network.wired.configSubtitle": {
+    "description": "Subtitle for the wired network configuration card",
+    "value": "Configure wired network settings for this device"
+  },
+  "network.wired.detailsTitle": {
+    "description": "Title of the wired network read-only details card",
+    "value": "Wired Network Details"
+  },
+  "network.wired.currentStatus": {
+    "description": "Title of the current wired network status card",
+    "value": "Current Wired Status"
+  },
+  "network.wired.configTitle": {
+    "description": "Title of the wired network configuration form",
+    "value": "Configure Wired Settings"
+  },
+  "network.wired.updateSuccess": {
+    "description": "Success message after updating wired network settings",
+    "value": "Wired network settings updated"
+  },
+  "network.wired.updateError": {
+    "description": "Error message when updating wired network settings fails",
+    "value": "Error updating wired network settings"
+  },
+  "network.changeAlert.title": {
+    "description": "Title of the dialog confirming a network settings change that may affect connectivity",
+    "value": "Confirm Network Change"
+  },
+  "network.changeAlert.message": {
+    "description": "Warning shown before saving a network change that may affect connectivity to the device",
+    "value": "Saving these settings may interrupt the connection to this device. Depending on the settings you chose, the connection may drop entirely (and require you to reconnect manually) or only briefly while the device requests a new DHCP address and reconnects. Do you want to continue?"
+  },
+  "network.changeAlert.wifiDisableNoWired": {
+    "description": "Warning shown before disabling WiFi on a device that has no wired adapter",
+    "value": "This device has no wired adapter, so disabling WiFi will drop the connection and there will be no way to reconnect to it remotely. Do you want to continue?"
+  },
+  "network.changeAlert.wifiDisableWithWired": {
+    "description": "Warning shown before disabling WiFi on a device that also has a wired adapter",
+    "value": "Disabling WiFi will permanently drop any WiFi connection to this device. Make sure you are connected through the wired adapter, or that you still have access to the device via the wired adapter, otherwise the connection will be lost. Do you want to continue?"
   },
   "network.wireless.defaultGateway": {
     "description": "Label for the wireless default gateway",
@@ -2161,7 +2229,15 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Label for wireless local profile synchronization",
-    "value": "Local Profile Synchronization"
+    "value": "OS WiFi Profile Synchronization"
+  },
+  "network.wireless.state": {
+    "description": "Label for wireless state",
+    "value": "WiFi Enabled"
+  },
+  "network.wireless.uefiProfileSync": {
+    "description": "Label for wireless UEFI profile synchronization status",
+    "value": "UEFI/CSME Wi-Fi Profile Sharing"
   },
   "network.wireless.macAddress": {
     "description": "Label for wireless MAC address",
@@ -2187,41 +2263,237 @@
     "description": "Label for wireless shared static IP",
     "value": "Shared Static IP"
   },
+  "network.wireless.sharedIP": {
+    "description": "Label for the derived wireless shared IP status",
+    "value": "Shared IP"
+  },
+  "network.sharedIP.static": {
+    "description": "Value shown when the device shares the host static IP address",
+    "value": "Shared (Static)"
+  },
+  "network.sharedIP.dynamic": {
+    "description": "Value shown when the device shares the host dynamic (DHCP) IP address",
+    "value": "Shared (Dynamic)"
+  },
+  "network.sharedIP.none": {
+    "description": "Value shown when the device does not share the host IP address",
+    "value": "Not Shared"
+  },
   "network.wireless.subnetMask": {
     "description": "Label for the wireless subnet mask",
     "value": "Subnet Mask"
   },
   "network.wireless.subtitle": {
     "description": "Subtitle for the wireless network settings card",
-    "value": "View wireless network settings for this device"
+    "value": "View or configure wireless network settings for this device"
   },
   "network.wireless.title": {
     "description": "Title of the wireless network settings card",
     "value": "Wireless Network Settings"
   },
-  "network.wirelessNetworks.name": {
-    "description": "Label for wireless network name",
-    "value": "Network Name: {{name}}"
+  "network.wireless.configSubtitle": {
+    "description": "Subtitle for the wireless network configuration card",
+    "value": "Configure wireless network settings for this device"
   },
-  "network.wirelessNetworks.ssid": {
-    "description": "Label for SSID",
-    "value": "SSID: {{ssid}}"
+  "network.wireless.detailsTitle": {
+    "description": "Title of the wireless network read-only details card",
+    "value": "Wireless Network Details"
   },
-  "network.wirelessNetworks.encryption": {
-    "description": "Label for encryption method",
-    "value": "Encryption: {{encryptMethod}}"
+  "network.wireless.currentStatus": {
+    "description": "Title of the current wireless network status card",
+    "value": "Current Wireless Status"
   },
-  "network.wirelessNetworks.auth": {
-    "description": "Label for authentication method",
-    "value": "Authentication: {{authMethod}}"
+  "network.wireless.configTitle": {
+    "description": "Title of the wireless configuration form",
+    "value": "Configure Wireless Settings"
   },
-  "network.wirelessNetworks.subtitle": {
-    "description": "Subtitle of the wireless networks card",
-    "value": "View wireless networks for this device"
+  "network.wireless.wifiEnabled": {
+    "description": "Label for the wireless state toggle when WiFi is enabled",
+    "value": "WiFi Enabled"
   },
-  "network.wirelessNetworks.title": {
-    "description": "Title of the wireless networks card",
-    "value": "Wireless Networks"
+  "network.wireless.wifiDisabled": {
+    "description": "Label for the wireless state toggle when WiFi is disabled",
+    "value": "WiFi Disabled"
+  },
+  "network.wireless.localProfileSyncToggle": {
+    "description": "Label for the local profile sync toggle",
+    "value": "Enable OS WiFi Profile Synchronization"
+  },
+  "network.wireless.uefiProfileSyncToggle": {
+    "description": "Label for the UEFI profile sync toggle",
+    "value": "Enable UEFI/CSME Wi-Fi Profile Sharing"
+  },
+  "network.wireless.uefiProfileSyncUnsupported": {
+    "description": "Hint shown when the device firmware does not support UEFI/CSME Wi-Fi profile sharing",
+    "value": "This device does not support UEFI/CSME Wi-Fi profile sharing."
+  },
+  "network.wireless.updateSuccess": {
+    "description": "Success message after updating wireless settings",
+    "value": "Wireless settings updated"
+  },
+  "network.wireless.updateError": {
+    "description": "Error message when updating wireless settings fails",
+    "value": "Error updating wireless settings"
+  },
+  "network.wirelessProfile.manageTitle": {
+    "description": "Title of the wireless profile management form",
+    "value": "Wireless Profile Management"
+  },
+  "network.wirelessProfile.manageSubtitle": {
+    "description": "Subtitle of the wireless profile management card",
+    "value": "Add, edit, or remove wireless profiles for this device"
+  },
+  "network.wirelessProfile.profileName": {
+    "description": "Label for the wireless profile name input",
+    "value": "Profile Name"
+  },
+  "network.wirelessProfile.ssid": {
+    "description": "Label for the wireless profile SSID input",
+    "value": "SSID"
+  },
+  "network.wirelessProfile.priority": {
+    "description": "Label for the wireless profile priority input",
+    "value": "Priority"
+  },
+  "network.wirelessProfile.authMethod": {
+    "description": "Label for the wireless profile authentication method select",
+    "value": "Authentication Method"
+  },
+  "network.wirelessProfile.encryptionMethod": {
+    "description": "Label for the wireless profile encryption method select",
+    "value": "Encryption Method"
+  },
+  "network.wirelessProfile.password": {
+    "description": "Label for the wireless profile password input",
+    "value": "Password"
+  },
+  "network.wirelessProfile.ieee8021xUsername": {
+    "description": "Label for the wireless profile 802.1x username input",
+    "value": "802.1x Username"
+  },
+  "network.wirelessProfile.ieee8021xProtocol": {
+    "description": "Label for the wireless profile 802.1x authentication protocol select",
+    "value": "802.1x Authentication Protocol"
+  },
+  "network.wirelessProfile.ieee8021xPassword": {
+    "description": "Label for the wireless profile 802.1x password input",
+    "value": "802.1x Password"
+  },
+  "network.wirelessProfile.ieee8021xPasswordRequired": {
+    "description": "Validation message when the 802.1x password is empty",
+    "value": "802.1x password is required"
+  },
+  "network.wirelessProfile.ieee8021xClientCert": {
+    "description": "Label for the wireless profile 802.1x client certificate input",
+    "value": "Client Certificate"
+  },
+  "network.wirelessProfile.ieee8021xClientCertRequired": {
+    "description": "Validation message when the 802.1x client certificate is empty",
+    "value": "Client certificate is required"
+  },
+  "network.wirelessProfile.ieee8021xPrivateKey": {
+    "description": "Label for the wireless profile 802.1x private key input",
+    "value": "Private Key"
+  },
+  "network.wirelessProfile.ieee8021xPrivateKeyRequired": {
+    "description": "Validation message when the 802.1x private key is empty",
+    "value": "Private key is required"
+  },
+  "network.wirelessProfile.ieee8021xCACert": {
+    "description": "Label for the wireless profile 802.1x CA certificate input",
+    "value": "CA Certificate"
+  },
+  "network.wirelessProfile.ieee8021xCACertHint": {
+    "description": "Hint for the optional wireless profile 802.1x CA certificate input",
+    "value": "Optional. Used to validate the RADIUS server certificate."
+  },
+  "network.wirelessProfile.ieee8021xCertUploaded": {
+    "description": "Status shown when an 802.1x certificate or key file has been uploaded",
+    "value": "Uploaded"
+  },
+  "network.wirelessProfile.ieee8021xCertNotUploaded": {
+    "description": "Status shown when no 802.1x certificate or key file has been uploaded",
+    "value": "No file selected"
+  },
+  "network.wirelessProfile.edit": {
+    "description": "Label for the edit wireless profile button",
+    "value": "Edit"
+  },
+  "network.wirelessProfile.addNew": {
+    "description": "Label for the add new wireless profile button",
+    "value": "Add Profile"
+  },
+  "network.wirelessProfile.empty": {
+    "description": "Message shown when there are no wireless profiles on the device",
+    "value": "No wireless profiles configured. Click \"Add Profile\" to create one."
+  },
+  "network.wirelessProfile.addTitle": {
+    "description": "Title for the add wireless profile form",
+    "value": "Add Wireless Profile"
+  },
+  "network.wirelessProfile.editTitle": {
+    "description": "Title for the edit wireless profile form",
+    "value": "Edit Wireless Profile"
+  },
+  "network.wirelessProfile.profileNameRequired": {
+    "description": "Validation message when the wireless profile name is empty",
+    "value": "Profile name is required"
+  },
+  "network.wirelessProfile.profileNamePattern": {
+    "description": "Validation message when the wireless profile name has invalid characters",
+    "value": "Only letters and numbers are allowed"
+  },
+  "network.wirelessProfile.ssidRequired": {
+    "description": "Validation message when the SSID is empty",
+    "value": "SSID is required"
+  },
+  "network.wirelessProfile.priorityRequired": {
+    "description": "Validation message when the priority is empty",
+    "value": "Priority is required"
+  },
+  "network.wirelessProfile.priorityRange": {
+    "description": "Validation message when the priority is out of range",
+    "value": "Priority must be between 1 and 255"
+  },
+  "network.wirelessProfile.priorityConflict": {
+    "description": "Validation message when the priority is already used by another wireless profile",
+    "value": "Priority is already in use by another profile"
+  },
+  "network.wirelessProfile.passwordRequired": {
+    "description": "Validation message when the password is too short or empty",
+    "value": "Password must be at least 8 characters"
+  },
+  "network.wirelessProfile.usernameRequired": {
+    "description": "Validation message when the 802.1x username is empty",
+    "value": "802.1x username is required"
+  },
+  "network.wirelessProfile.saveSuccess": {
+    "description": "Success message after saving a wireless profile",
+    "value": "Wireless profile saved"
+  },
+  "network.wirelessProfile.saveError": {
+    "description": "Error message when saving a wireless profile fails",
+    "value": "Error saving wireless profile"
+  },
+  "network.wirelessProfile.deleteSuccess": {
+    "description": "Success message after deleting a wireless profile",
+    "value": "Wireless profile deleted"
+  },
+  "network.wirelessProfile.deleteError": {
+    "description": "Error message when deleting a wireless profile fails",
+    "value": "Error deleting wireless profile"
+  },
+  "network.wirelessProfile.limitReached": {
+    "description": "Tooltip shown on the add button when the device already has the maximum number of wireless profiles",
+    "value": "Maximum of {{max}} wireless profiles reached. Remove a profile before adding a new one."
+  },
+  "network.wirelessProfile.wifiDisabledAlertTitle": {
+    "description": "Title of the dialog shown when adding a profile while WiFi is disabled",
+    "value": "WiFi Disabled"
+  },
+  "network.wirelessProfile.wifiDisabledAlert": {
+    "description": "Warning message shown when adding a profile while WiFi is disabled",
+    "value": "WiFi is currently disabled. This profile will not take effect until WiFi is enabled."
   },
   "pba.enforceCCMMessage": {
     "value": "Secure Boot is always enforced in Client Control Mode (CCM)"

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Etiqueta para la sincronización inalámbrica de perfiles locales.",
-    "value": "Sincronización de perfiles locales"
+    "value": "Sincronización de perfiles WiFi del sistema operativo"
   },
   "network.wireless.macAddress": {
     "description": "Etiqueta para la dirección MAC inalámbrica",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Langattoman paikallisen profiilin synkronoinnin tunniste",
-    "value": "Paikallisen profiilin synkronointi"
+    "value": "Käyttöjärjestelmän Wi-Fi-profiilien synkronointi"
   },
   "network.wireless.macAddress": {
     "description": "Langattoman MAC-osoitteen tunniste",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Étiquette pour la synchronisation sans fil des profils locaux",
-    "value": "Synchronisation des profils locaux"
+    "value": "Synchronisation des profils Wi-Fi du système d'exploitation"
   },
   "network.wireless.macAddress": {
     "description": "Étiquette pour l'adresse MAC sans fil",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "תווית לסנכרון פרופיל מקומי אלחוטי",
-    "value": "סנכרון פרופיל מקומי"
+    "value": "סנכרון פרופילי Wi-Fi של מערכת ההפעלה"
   },
   "network.wireless.macAddress": {
     "description": "תווית לכתובת MAC אלחוטית",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Etichetta per la sincronizzazione wireless del profilo locale",
-    "value": "Sincronizzazione del profilo locale"
+    "value": "Sincronizzazione dei profili Wi-Fi del sistema operativo"
   },
   "network.wireless.macAddress": {
     "description": "Etichetta per indirizzo MAC wireless",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "ワイヤレスローカルプロファイル同期のラベル",
-    "value": "ローカルプロファイルの同期"
+    "value": "OS Wi-Fiプロファイル同期"
   },
   "network.wireless.macAddress": {
     "description": "無線MACアドレスのラベル",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Label voor draadloze lokale profielsynchronisatie",
-    "value": "Lokale profielsynchronisatie"
+    "value": "Synchronisatie van OS-wifi-profielen"
   },
   "network.wireless.macAddress": {
     "description": "Label voor draadloos MAC-adres",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Метка для беспроводной синхронизации локального профиля",
-    "value": "Синхронизация локального профиля"
+    "value": "Синхронизация Wi-Fi-профилей ОС"
   },
   "network.wireless.macAddress": {
     "description": "Метка для беспроводного MAC-адреса",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1978,7 +1978,7 @@
   },
   "network.wireless.localProfileSync": {
     "description": "Etikett för trådlös lokal profilsynkronisering",
-    "value": "Synkronisering av lokala profiler"
+    "value": "Synkronisering av OS Wi-Fi-profiler"
   },
   "network.wireless.macAddress": {
     "description": "Etikett för trådlös MAC-adress",

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -383,7 +383,7 @@ export interface TLSSettings {
   NonSecureConnectionsSupported: boolean
 }
 
-interface WiFiPortConfigService {
+export interface WiFiPortConfigService {
   requestedState: number
   enabledState: number
   healthState: number
@@ -398,7 +398,7 @@ interface WiFiPortConfigService {
   uefiWiFiProfileShareEnabled: boolean
 }
 
-interface WiredNetworkSettings {
+export interface WiredNetworkSettings {
   elementName: string
   instanceID: string
   vlanTag: number
@@ -422,7 +422,7 @@ interface WiredNetworkSettings {
   ieee8021x: Ieee8021x
 }
 
-interface WirelessNetworkSettings {
+export interface WirelessNetworkSettings {
   elementName: string
   instanceID: string
   vlanTag: number
@@ -453,6 +453,74 @@ interface WirelessNetworkSettings {
 export interface NetworkConfig {
   wired: WiredNetworkSettings
   wireless: WirelessNetworkSettings
+}
+
+export interface WiredNetworkConfigRequest {
+  dhcpEnabled: boolean
+  ipSyncEnabled?: boolean
+  ipAddress?: string
+  subnetMask?: string
+  defaultGateway?: string
+  primaryDNS?: string
+  secondaryDNS?: string
+  ieee8021x?: {
+    profileName: string
+    authenticationProtocol: number
+    username: string
+    password: string
+    privateKey: string
+    clientCert: string
+    caCert: string
+  }
+}
+
+export type WirelessState = 'WifiDisabled' | 'WifiEnabledS0' | 'WifiEnabledS0SxAC'
+
+export interface WirelessStateResponse {
+  state: WirelessState
+}
+
+export interface WirelessStateChangeRequest {
+  state: WirelessState
+}
+
+export interface WirelessProfileSyncRequest {
+  localProfileSync: boolean
+  uefiProfileSync: boolean
+}
+
+export interface WirelessProfileSyncResponse {
+  localProfileSync: boolean
+  uefiProfileSync: boolean
+  uefiProfileSyncSupported: boolean
+}
+
+export interface DeviceWirelessIEEE8021x {
+  username: string
+  authenticationProtocol: number
+  password?: string
+  clientCert?: string
+  privateKey?: string
+  caCert?: string
+}
+
+export interface DeviceWirelessProfileRequest {
+  profileName: string
+  ssid: string
+  authenticationMethod: string
+  encryptionMethod: string
+  priority: number
+  password?: string
+  ieee8021x?: DeviceWirelessIEEE8021x
+}
+
+export interface DeviceWirelessProfileResponse {
+  profileName: string
+  ssid: string
+  authenticationMethod: string
+  encryptionMethod: string
+  priority: number
+  ieee8021x?: DeviceWirelessIEEE8021x
 }
 
 export interface RedirectionStatus {


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [x] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

Add a Network Settings tab to the device view for managing wired and wireless network configuration directly on a device.

Wired:
- View link/IP details and IEEE 802.1x status
- Configure DHCP or static IP, with IP synchronization

Wireless:
- View link/IP details and toggle Wi-Fi state
- Manage local and UEFI profile synchronization
- Create, edit and delete wireless profiles (sorted by priority)
- Support PSK and IEEE 802.1x auth; for 802.1x, PEAP uses a password and EAP-TLS uploads client certificate, private key and optional CA certificate (uploaded as base64 DER, matching the backend)

Add the corresponding DevicesService endpoints, request/response models. Includes unit tests for the new service methods and component.

Resolves: #3353

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )

## UI sample

### wired

<img width="619" height="1034" alt="image" src="https://github.com/user-attachments/assets/1a7be9f5-73b7-4ab4-89bd-693393933f64" />

### wireless

<img width="617" height="1133" alt="image" src="https://github.com/user-attachments/assets/6ea411fc-2e06-4104-b480-e5cf530dd423" />
<img width="619" height="1171" alt="image" src="https://github.com/user-attachments/assets/ca015df0-b0c9-4327-a844-e35b4066a720" />
