### PR TITLE
fix(e2e): update rpc-go v3 CLI flags

### DIFF
--- a/cypress/e2e/integration/rpc/activation.spec.ts
+++ b/cypress/e2e/integration/rpc/activation.spec.ts
@@ -74,10 +74,125 @@ export const execWithRetry = (
   return attemptExec(1)
 }
 
+// Runs `rpc amtinfo` and parses the JSON result. Tolerates leading log noise
+// (e.g. logrus-formatted warnings) by locating the first '{' in the output.
+export const getAmtInfo = (
+  infoCommand: string,
+  config: Cypress.ExecOptions = execConfig
+): Cypress.Chainable<AMTInfo> => {
+  return cy.exec(infoCommand, config).then((result) => {
+    const { stdout, stderr, combined } = buildOutput(result)
+    return cy.log(combined).then(() => {
+      const source = stdout.length > 0 ? stdout : stderr
+      const jsonStart = source.indexOf('{')
+      if (jsonStart < 0) {
+        throw new Error(`rpc amtinfo did not return JSON. Output:\n${combined}`)
+      }
+      const jsonOutput = source.substring(jsonStart)
+      return JSON.parse(jsonOutput) as AMTInfo
+    })
+  })
+}
+
+// Extracts the major AMT version (e.g. "16.1.5" -> "16") from an AMTInfo object.
+export const getAmtVersion = (amtInfo: AMTInfo): string => {
+  const versions: string[] = amtInfo.amt.split('.')
+  return versions.length > 1 ? versions[0] : '0'
+}
+
+// rpc-go has reported the not-yet-activated control mode under different
+// strings across versions/builds; treat either as "not activated".
+export const notActivatedControlModes: string[] = ['pre-provisioning state', 'not activated']
+
 // ---- Computed environment flags -------------------------------------------
 
-// Exported so sub-specs can import them directly when run standalone.
-const isCloud: boolean = Cypress.env('CLOUD') === 'true' || Cypress.env('CLOUD') === true
+// Exported so sub-specs (and the builders below) can use it to pick the
+// cloud vs. console command variant.
+export const isCloud: boolean = Cypress.env('CLOUD') === 'true' || Cypress.env('CLOUD') === true
+
+// ---- Shared rpc-go command builders ---------------------------------------
+//
+// rpc-go v3 (Kong CLI) requires --long/-short flag syntax; bare single-dash
+// long flags (e.g. -json, -configv2) are no longer accepted. Commands are run
+// either via Docker (Linux/Mac) or directly via rpc.exe (Windows). Each builder
+// uses `isCloud` to decide between the cloud (RPS/wss) and console (local
+// profile) variant of the command.
+
+export interface RpcCommandOptions {
+  isWin: boolean
+  rpcDockerImage: string
+  volumeMount?: string
+}
+
+const buildRpcCommand = (opts: RpcCommandOptions, winExe: string, args: string): string => {
+  if (opts.isWin) {
+    return `${winExe} ${args}`
+  }
+  const volumeFlag = opts.volumeMount ? ` -v ${opts.volumeMount}` : ''
+  return `docker run --rm --network host --device=/dev/mei0${volumeFlag} ${opts.rpcDockerImage} ${args}`
+}
+
+export const buildInfoCommand = (opts: RpcCommandOptions): string => buildRpcCommand(opts, 'rpc.exe', 'amtinfo --json')
+
+export interface ActivateCommandOptions {
+  isWin: boolean
+  rpcDockerImage: string
+  amtVersion: string
+  // console-only
+  profileYamlFile?: string
+  encryptionKey?: string
+  // cloud-only
+  fqdn?: string
+  profileName?: string
+}
+
+export const buildActivateCommand = (opts: ActivateCommandOptions): string => {
+  const cmd = `activate`
+  const common_flag = `-v --json`
+  if (isCloud) {
+    const flagPart = parseInt(opts.amtVersion) <= 18 ? ' -tls-tunnel' : ''
+    const args = `${cmd} -u wss://${opts.fqdn}/activate --profile ${opts.profileName} -n${flagPart} ${common_flag}`
+    return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
+  }
+
+  const profileDir = opts.profileYamlFile
+    ? opts.profileYamlFile.substring(0, opts.profileYamlFile.lastIndexOf('/'))
+    : ''
+  const profileFileName = opts.profileYamlFile
+    ? opts.profileYamlFile.substring(opts.profileYamlFile.lastIndexOf('/') + 1)
+    : ''
+  const profilePath = opts.isWin ? opts.profileYamlFile : `/config/${profileFileName}`
+  const flagPart = parseInt(opts.amtVersion) <= 18 ? '' : ' --skip-amt-cert-check'
+  const args = `${cmd} --profile ${profilePath} --key ${opts.encryptionKey}${flagPart} ${common_flag}`
+  return buildRpcCommand(
+    { isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage, volumeMount: `${profileDir}:/config` },
+    'rpc.exe',
+    args
+  )
+}
+
+export interface DeactivateCommandOptions {
+  isWin: boolean
+  rpcDockerImage: string
+  password: string
+  amtVersion: string
+  // cloud-only
+  fqdn?: string
+}
+
+export const buildDeactivateCommand = (opts: DeactivateCommandOptions): string => {
+  const cmd = `deactivate`
+  const common_flag = `-v -f --json --password ${opts.password}`
+  if (isCloud) {
+    const flagPart = parseInt(opts.amtVersion) <= 18 ? ' -tls-tunnel' : ''
+    const args = `${cmd} -u wss://${opts.fqdn}/activate -n${flagPart} ${common_flag}`
+    return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
+  }
+
+  const flagPart = parseInt(opts.amtVersion) <= 18 ? '' : ' --skip-amt-cert-check'
+  const args = `${cmd} --local${flagPart} ${common_flag}`
+  return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
+}
 
 declare const require: (id: string) => unknown
 

--- a/cypress/e2e/integration/rpc/cloud.activation.spec.ts
+++ b/cypress/e2e/integration/rpc/cloud.activation.spec.ts
@@ -11,7 +11,18 @@
 // ISOLATE guard below acts as a safety net.
 // ---------------------------------------------------------------------------
 
-import { AMTInfo, execConfig, buildOutput, execWithRetry } from './activation.spec'
+import {
+  AMTInfo,
+  execConfig,
+  buildOutput,
+  execWithRetry,
+  buildInfoCommand,
+  buildActivateCommand,
+  buildDeactivateCommand,
+  getAmtInfo,
+  getAmtVersion,
+  notActivatedControlModes
+} from './activation.spec'
 
 if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
   {
@@ -25,72 +36,52 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
     const parts: string[] = profileName ? profileName.split('-') : []
     const isAdminControlModeProfile = parts.length > 0 && parts[0] === 'acmactivate'
     const isWin = Cypress.platform === 'win32'
-    let majorVersion = ''
 
-    // Default: use Docker (Linux/Mac); Windows overrides below use rpc.exe directly
-    let infoCommand = `docker run --rm --network host --device=/dev/mei0 ${rpcDockerImage} amtinfo --json`
+    // Default: use Docker (Linux/Mac); Windows overrides handled internally by the builders.
+    const infoCommand = buildInfoCommand({ isWin, rpcDockerImage })
     let activateCommand = ''
     let deactivateCommand = ''
+    let amtVersion = ''
 
-    const buildActivateCommand = (useFlag: boolean, flag = '') => {
-      const flagPart = useFlag ? ` ${flag}` : ''
-      if (isWin) {
-        return `rpc.exe activate -u wss://${fqdn}/activate -v -n${flagPart} --profile ${profileName} --json`
-      }
-      return `docker run --rm --network host --device=/dev/mei0 ${rpcDockerImage} activate -u wss://${fqdn}/activate -v -n${flagPart} --profile ${profileName} --json`
-    }
-
-    const buildDeactivateCommand = () => {
-      if (isWin) {
-        return `rpc.exe deactivate -u wss://${fqdn}/activate -v -n -f --json --password ${password}`
-      }
-      return `docker run --rm --network host --device=/dev/mei0 ${rpcDockerImage} deactivate -u wss://${fqdn}/activate -v -n -f --json --password ${password}`
-    }
-
-    const updateCommandsForVersion = (version: string): void => {
-      if (parseInt(version) <= 18) {
-        cy.log(`AMT version ${version} detected (<= 18), using -tls-tunnel flag for activate`)
-        activateCommand = buildActivateCommand(true, '-tls-tunnel')
-      } else {
-        cy.log(`AMT version ${version} detected (> 18), no extra flag needed`)
-        activateCommand = buildActivateCommand(false)
-      }
-      deactivateCommand = buildDeactivateCommand()
-    }
-
-    if (isWin) {
-      infoCommand = 'rpc.exe amtinfo --json'
-    }
-
-    // Set initial commands without flag (will be updated based on AMT version)
-    activateCommand = buildActivateCommand(false)
-    deactivateCommand = buildDeactivateCommand()
+    before(() => {
+      getAmtInfo(infoCommand).then((info) => {
+        amtVersion = getAmtVersion(info)
+        activateCommand = buildActivateCommand({
+          isWin,
+          rpcDockerImage,
+          amtVersion,
+          fqdn,
+          profileName
+        })
+        deactivateCommand = buildDeactivateCommand({
+          isWin,
+          rpcDockerImage,
+          password,
+          amtVersion,
+          fqdn
+        })
+      })
+    })
 
     describe('Device Activation - Cloud', () => {
       context('TC_ACTIVATION_DEVICE_ACTIVATE_AND_DEACTIVATE', () => {
         beforeEach(() => {
           cy.setup()
-          cy.exec(infoCommand, execConfig).then((result) => {
-            const { stdout, stderr, combined } = buildOutput(result)
-            cy.log(combined)
-            const source = stdout.length > 0 ? stdout : stderr
-            amtInfo = JSON.parse(source)
-            const versions: string[] = amtInfo.amt.split('.')
-            majorVersion = versions.length > 1 ? versions[0] : '0'
-            updateCommandsForVersion(majorVersion)
+          getAmtInfo(infoCommand).then((info) => {
+            amtInfo = info
           })
           cy.wait(1000)
         })
 
         it('Should Activate Device', () => {
-          expect(amtInfo.controlMode).to.contain('pre-provisioning state')
+          expect(amtInfo.controlMode).to.be.oneOf(notActivatedControlModes)
 
           execWithRetry(activateCommand, execConfig).then((result) => {
             const { stdout, stderr, combined } = buildOutput(result)
             cy.log(combined)
             const primaryOutput = stdout.length > 0 ? stdout : stderr
 
-            if (parseInt(majorVersion) < 12 && parseInt(amtInfo.buildNumber) < 3000) {
+            if (parseInt(amtVersion) < 12 && parseInt(amtInfo.buildNumber) < 3000) {
               expect(combined).to.contain(
                 'Only version 10.0.47 with build greater than 3000 can be remotely configured'
               )
@@ -106,7 +97,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
 
             if (parts[2] === 'CIRA') {
               expect(combined).to.match(/CIRA: Configured/i)
-            } else if (parseInt(majorVersion) >= 19) {
+            } else if (parseInt(amtVersion) >= 19) {
               expect(combined).to.match(/TLS: Already Configured/i)
             } else {
               expect(combined).to.match(/TLS: Configured/i)
@@ -131,10 +122,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
             cy.wait(120000)
 
             // Re-query amtinfo after activation to get the updated IP address
-            cy.exec(infoCommand, execConfig).then((postActivationResult) => {
-              const { stdout, stderr } = buildOutput(postActivationResult)
-              const source = stdout.length > 0 ? stdout : stderr
-              const postActivationInfo: AMTInfo = JSON.parse(source)
+            getAmtInfo(infoCommand).then((postActivationInfo) => {
               cy.log(`Post-activation wired IP: ${postActivationInfo.wiredAdapter?.ipAddress}`)
               cy.log(`Post-activation wireless IP: ${postActivationInfo.wirelessAdapter?.ipAddress}`)
 
@@ -154,7 +142,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
             cy.get('[data-cy="serialNumber"]').should('not.be.empty')
             cy.get('[data-cy="provisioningMode"]').should('not.be.empty')
 
-            if (parseInt(majorVersion) < 11) {
+            if (parseInt(amtVersion) < 11) {
               cy.get('[data-cy="biosManufacturer"]').should('not.be.empty')
               cy.get('[data-cy="biosVersion"]').should('not.be.empty')
               cy.get('[data-cy="biosReleaseData"]').should('not.be.empty')
@@ -171,7 +159,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
         })
 
         it('should NOT deactivate device - invalid password', () => {
-          if (amtInfo.controlMode !== 'pre-provisioning state') {
+          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
             const invalidCommand =
               deactivateCommand.slice(0, deactivateCommand.indexOf('--password')) + '--password invalidpassword'
             execWithRetry(invalidCommand, execConfig).then((result) => {
@@ -183,7 +171,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
         })
 
         it('should deactivate device', () => {
-          if (amtInfo.controlMode !== 'pre-provisioning state') {
+          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
             execWithRetry(deactivateCommand, execConfig).then((result) => {
               const { combined } = buildOutput(result)
               cy.log(combined)
@@ -196,17 +184,6 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
     })
 
     context('Negative Activation Test', () => {
-      beforeEach(() => {
-        cy.exec(infoCommand, execConfig).then((result) => {
-          const { stdout, stderr } = buildOutput(result)
-          const source = stdout.length > 0 ? stdout : stderr
-          const info = JSON.parse(source)
-          const versions: string[] = info.amt.split('.')
-          const version = versions.length > 1 ? versions[0] : '0'
-          updateCommandsForVersion(version)
-        })
-      })
-
       if (isAdminControlModeProfile) {
         it('Should NOT activate ACM when domain suffix is not registered in RPS', () => {
           activateCommand += ' -d dontmatch.com'

--- a/cypress/e2e/integration/rpc/console.activation.spec.ts
+++ b/cypress/e2e/integration/rpc/console.activation.spec.ts
@@ -11,7 +11,18 @@
 // ISOLATE guard below acts as a safety net.
 // ---------------------------------------------------------------------------
 
-import { AMTInfo, execConfig, buildOutput, execWithRetry } from './activation.spec'
+import {
+  AMTInfo,
+  execConfig,
+  buildOutput,
+  execWithRetry,
+  buildInfoCommand,
+  buildActivateCommand,
+  buildDeactivateCommand,
+  getAmtInfo,
+  getAmtVersion,
+  notActivatedControlModes
+} from './activation.spec'
 
 if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
   {
@@ -25,49 +36,52 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
     const isAdminControlModeProfile = parts.length > 0 && parts[0] === 'acmactivate'
     const profileYamlFile: string = Cypress.env('PROFILE_YAML_FILE')
     const encryptionKey: string = Cypress.env('ENCRYPTION_KEY')
-    let majorVersion = ''
     const isWin = Cypress.platform === 'win32'
 
-    // Derive directory and filename from the full YAML path
-    const profileDir = profileYamlFile ? profileYamlFile.substring(0, profileYamlFile.lastIndexOf('/')) : ''
-    const profileFileName = profileYamlFile ? profileYamlFile.substring(profileYamlFile.lastIndexOf('/') + 1) : ''
+    // Default: use Docker (Linux/Mac); Windows overrides handled internally by the builders.
+    const infoCommand = buildInfoCommand({ isWin, rpcDockerImage })
+    let activateCommand = ''
+    let deactivateCommand = ''
+    let amtVersion = ''
 
-    // Default: use Docker (Linux/Mac); Windows overrides below use rpc.exe directly
-    let infoCommand = `docker run --rm --network host --device=/dev/mei0 -v ${profileDir}:/config ${rpcDockerImage} amtinfo -json`
-    let activateCommand = `docker run --rm --network host --device=/dev/mei0 -v ${profileDir}:/config ${rpcDockerImage} activate -local -configv2 /config/${profileFileName} -configencryptionkey ${encryptionKey} -v -skipamtcertcheck -json`
-    let deactivateCommand = `docker run --rm --network host --device=/dev/mei0 -v ${profileDir}:/config ${rpcDockerImage} deactivate -local -v -skipamtcertcheck -f -json -password ${password}`
-
-    if (isWin) {
-      activateCommand = `rpc.exe activate -local -configv2 ${profileYamlFile} -configencryptionkey ${encryptionKey} -v -skipamtcertcheck -json`
-      infoCommand = 'rpc.exe amtinfo -json'
-      deactivateCommand = `rpc.exe deactivate -local -v -skipamtcertcheck -f -json -password ${password}`
-    }
+    before(() => {
+      getAmtInfo(infoCommand).then((info) => {
+        amtVersion = getAmtVersion(info)
+        activateCommand = buildActivateCommand({
+          isWin,
+          rpcDockerImage,
+          amtVersion,
+          profileYamlFile,
+          encryptionKey
+        })
+        deactivateCommand = buildDeactivateCommand({
+          isWin,
+          rpcDockerImage,
+          password,
+          amtVersion
+        })
+      })
+    })
 
     describe('Device Activation - Console', () => {
       context('TC_ACTIVATION_DEVICE_ACTIVATE_AND_DEACTIVATE', () => {
         beforeEach(() => {
           cy.setup()
-          cy.exec(infoCommand, execConfig).then((result) => {
-            const { stdout, stderr, combined } = buildOutput(result)
-            cy.log(combined)
-            const source = stdout.length > 0 ? stdout : stderr
-            const jsonOutput = source.substring(source.indexOf('{'))
-            amtInfo = JSON.parse(jsonOutput)
-            const versions: string[] = amtInfo.amt.split('.')
-            majorVersion = versions.length > 1 ? versions[0] : '0'
+          getAmtInfo(infoCommand).then((info) => {
+            amtInfo = info
           })
           cy.wait(1000)
         })
 
         it('Should Activate Device', () => {
-          expect(amtInfo.controlMode).to.contain('pre-provisioning state')
+          expect(amtInfo.controlMode).to.be.oneOf(notActivatedControlModes)
 
           execWithRetry(activateCommand, execConfig).then((result) => {
             const { stdout, stderr, combined } = buildOutput(result)
             cy.log(combined)
             const primaryOutput = stdout.length > 0 ? stdout : stderr
 
-            if (parseInt(majorVersion) < 12 && parseInt(amtInfo.buildNumber) < 3000) {
+            if (parseInt(amtVersion) < 12 && parseInt(amtInfo.buildNumber) < 3000) {
               expect(combined).to.contain(
                 'Only version 10.0.47 with build greater than 3000 can be remotely configured'
               )
@@ -93,11 +107,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
             cy.wait(120000)
 
             // Re-query amtinfo after activation to get the updated IP address
-            cy.exec(infoCommand, execConfig).then((postActivationResult) => {
-              const { stdout, stderr } = buildOutput(postActivationResult)
-              const source = stdout.length > 0 ? stdout : stderr
-              const postActivationInfo: AMTInfo = JSON.parse(source)
-
+            getAmtInfo(infoCommand).then((postActivationInfo) => {
               cy.intercept(/devices\/.*$/).as('getdevices')
               cy.goToPage('Devices')
               cy.wait('@getdevices')
@@ -127,7 +137,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
             cy.get('[data-cy="serialNumber"]').should('not.be.empty')
             cy.get('[data-cy="provisioningMode"]').should('not.be.empty')
 
-            if (parseInt(majorVersion) < 11) {
+            if (parseInt(amtVersion) < 11) {
               cy.get('[data-cy="biosManufacturer"]').should('not.be.empty')
               cy.get('[data-cy="biosVersion"]').should('not.be.empty')
               cy.get('[data-cy="biosReleaseDate"]').should('not.be.empty')
@@ -144,19 +154,19 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
         })
 
         it('should NOT deactivate device - invalid password', () => {
-          if (amtInfo.controlMode !== 'pre-provisioning state') {
+          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
             const invalidCommand =
-              deactivateCommand.slice(0, deactivateCommand.indexOf('-password')) + '-password invalidpassword'
+              deactivateCommand.slice(0, deactivateCommand.indexOf('--password')) + '--password invalidpassword'
             execWithRetry(invalidCommand, execConfig).then((result) => {
               const { combined } = buildOutput(result)
               cy.log(combined)
-              expect(combined).to.contain('Deactivation failed.Error 109: UnableToDeactivate')
+              expect(combined).to.contain('Error 109: UnableToDeactivate')
             })
           }
         })
 
         it('should deactivate device', () => {
-          if (amtInfo.controlMode !== 'pre-provisioning state') {
+          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
             execWithRetry(deactivateCommand, execConfig).then((result) => {
               const { combined } = buildOutput(result)
               cy.log(combined)


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [x] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

- Update rpc.exe/docker invocations to rpc-go v3 Kong CLI syntax (--json, --skip-amt-cert-check, --password, -configv2 -> --profile), fixing the JSON.parse failures caused by the old single-dash flags.
- Extract getAmtInfo/getAmtVersion and buildInfoCommand/ buildActivateCommand/buildDeactivateCommand into activation.spec.ts so cloud and console specs share one implementation instead of duplicating command-string building and amtinfo parsing.
- Replace the per-file updateCommandsForVersion closures with a single root-level before() hook that builds the activate command once per spec file using the detected AMT version.

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )

tested using workflow dispatch: [https://github.com/device-management-toolkit/e2e-testing/pull/110](https://github.com/device-management-toolkit/e2e-testing/pull/110)
