### PR TITLE
test: skip invalid password test for console ccm

### DIFF
--- a/cypress/e2e/integration/rpc/activation.spec.ts
+++ b/cypress/e2e/integration/rpc/activation.spec.ts
@@ -176,21 +176,24 @@ export interface DeactivateCommandOptions {
   rpcDockerImage: string
   password: string
   amtVersion: string
+  // console-only
+  isAdminControlModeProfile?: boolean
   // cloud-only
   fqdn?: string
 }
 
 export const buildDeactivateCommand = (opts: DeactivateCommandOptions): string => {
   const cmd = `deactivate`
-  const common_flag = `-v -f --json --password ${opts.password}`
+  const common_flag = `-v -f --json`
   if (isCloud) {
     const flagPart = parseInt(opts.amtVersion) <= 18 ? ' -tls-tunnel' : ''
-    const args = `${cmd} -u wss://${opts.fqdn}/activate -n${flagPart} ${common_flag}`
+    const args = `${cmd} -u wss://${opts.fqdn}/activate -n${flagPart} --password ${opts.password} ${common_flag}`
     return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
   }
 
   const flagPart = parseInt(opts.amtVersion) <= 18 ? '' : ' --skip-amt-cert-check'
-  const args = `${cmd} --local${flagPart} ${common_flag}`
+  const passPart = opts.isAdminControlModeProfile ? ` --password ${opts.password}` : ''
+  const args = `${cmd} --local${flagPart}${passPart} ${common_flag}`
   return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
 }
 

--- a/cypress/e2e/integration/rpc/console.activation.spec.ts
+++ b/cypress/e2e/integration/rpc/console.activation.spec.ts
@@ -58,7 +58,8 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
           isWin,
           rpcDockerImage,
           password,
-          amtVersion
+          amtVersion,
+          isAdminControlModeProfile
         })
       })
     })
@@ -153,7 +154,11 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
           })
         })
 
-        it('should NOT deactivate device - invalid password', () => {
+        it('should NOT deactivate device - invalid password', function () {
+          if (!isAdminControlModeProfile) {
+            this.skip()
+          }
+
           if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
             const invalidCommand =
               deactivateCommand.slice(0, deactivateCommand.indexOf('--password')) + '--password invalidpassword'


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [x] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

skip invalid password test for console ccm activation as password is no longer required for local ccm deactivation

update buildDeactivateCommand to skip password argument if ccm

commit that disable password for local ccm deactivation: [rpc-go commit#5c44be5ad97834583a528502db35390e2e6cac89](https://github.com/device-management-toolkit/rpc-go/commit/5c44be5ad97834583a528502db35390e2e6cac89)

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )

workflow test: [https://github.com/device-management-toolkit/e2e-testing/actions/runs/28842006619/job/85538723795](https://github.com/device-management-toolkit/e2e-testing/actions/runs/28842006619/job/85538723795)