### PR TITLE
build(deps): bump github/codeql-action from 4.36.2 to 4.37.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -80,7 +80,7 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
     - name: Generate Security Report
       uses: rsdmike/github-security-report-action@a149b24539044c92786ec39af8ba38c93496495d # v3.0.4
       continue-on-error: true


### PR DESCRIPTION
Bumps `github/codeql-action` to `4.37.0` (commit `99df26d`).

Updates all three sub-actions used in `.github/workflows/codeql-analysis.yml` together, since they share the same pinned commit SHA and are interdependent. Also corrects the stale `# v3.29.5` version comment to `# v4.37.0`.

- `github/codeql-action/init`
- `github/codeql-action/autobuild`
- `github/codeql-action/analyze`

Supersedes and combines the three separate dependabot PRs (bringing autobuild up to 4.37.0 to match init and analyze):
- Closes #3409 (init → 4.37.0)
- Closes #3410 (autobuild → 4.36.3)
- Closes #3412 (analyze → 4.37.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)