### PR TITLE
refactor: rename deviceInfo lastUpdated to lastSynced, add firstDiscovered

### DIFF
--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -31,7 +31,8 @@ export interface DeviceInfo {
   currentMode: string
   features: string
   ipAddress: string
-  lastUpdated?: Date
+  firstDiscovered?: Date
+  lastSynced?: Date
 }
 export interface DeviceStats {
   totalCount: number


### PR DESCRIPTION
Aligns DeviceInfo model with console discovery-timestamp changes. Type-only field; not rendered, so no runtime dependency on the API change.

Related to device-management-toolkit/rpc-go#1394

Note:
Kept the sample-web-ui change scoped to the lastUpdated->lastSynced rename (+ firstDiscovered as the timestamp pair). The remaining discovery fields (osName, SKU type, control mode filters, certHashes, etc.) are owned by the Discovery Dashboard work - console#1093 and sample-web-ui#1265 - and should be added there alongside the columns/filters that render them, not speculatively here.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
