### PR TITLE
fix: validate JWT expiration with clock skew tolerance

### DIFF
--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -13,8 +13,21 @@ describe('AuthService', () => {
   let routerSpy: jasmine.SpyObj<Router>
 
   const mockEnvironment = { mpsServer: 'https://test-mps', rpsServer: 'https://test-rps' }
+  const createJwtWithExp = (expSeconds: number): string => {
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '')
+    const payload = btoa(JSON.stringify({ exp: expSeconds }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '')
+    return `${header}.${payload}.signature`
+  }
 
   beforeEach(() => {
+    localStorage.clear()
+
     routerSpy = jasmine.createSpyObj('Router', ['navigate'])
     environment.mpsServer = mockEnvironment.mpsServer
     environment.rpsServer = mockEnvironment.rpsServer
@@ -35,6 +48,7 @@ describe('AuthService', () => {
 
   afterEach(() => {
     httpMock.verify()
+    localStorage.clear()
   })
 
   it('should be created', () => {
@@ -198,6 +212,140 @@ describe('AuthService', () => {
       expect(service.compareSemver('1.0.0', '1.0.1')).toBeLessThan(0)
       expect(service.compareSemver('1.2.0', '1.1.5')).toBeGreaterThan(0)
       expect(service.compareSemver('1.0.0', '1.0.0')).toBe(0)
+    })
+  })
+
+  describe('constructor token validation', () => {
+    it('should accept a non-expired token from localStorage', () => {
+      const validJwt = createJwtWithExp(Math.floor(Date.now() / 1000) + 300)
+      localStorage.setItem('loggedInUser', JSON.stringify({ token: validJwt }))
+
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideTranslateService(),
+          AuthService,
+          { provide: Router, useValue: routerSpy },
+          provideHttpClient(),
+          provideHttpClientTesting()
+        ]
+      })
+
+      const newService = TestBed.inject(AuthService)
+      const newHttpMock = TestBed.inject(HttpTestingController)
+
+      // Should not make any HTTP calls during construction
+      newHttpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/devices/stats`)
+
+      expect(newService.isLoggedIn).toBeTrue()
+      expect(localStorage.getItem('loggedInUser')).not.toBeNull()
+      newHttpMock.verify()
+    })
+
+    it('should accept a recently expired token within the clock-skew tolerance', () => {
+      // Token expired 3 minutes ago (within 5-minute tolerance)
+      const toleratedJwt = createJwtWithExp(Math.floor(Date.now() / 1000) - 3 * 60)
+      localStorage.setItem('loggedInUser', JSON.stringify({ token: toleratedJwt }))
+
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideTranslateService(),
+          AuthService,
+          { provide: Router, useValue: routerSpy },
+          provideHttpClient(),
+          provideHttpClientTesting()
+        ]
+      })
+
+      const newService = TestBed.inject(AuthService)
+      const newHttpMock = TestBed.inject(HttpTestingController)
+
+      // Should not make a server call for tokens still valid within skew tolerance
+      newHttpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/devices/stats`)
+
+      expect(newService.isLoggedIn).toBeTrue()
+      expect(localStorage.getItem('loggedInUser')).not.toBeNull()
+      newHttpMock.verify()
+    })
+
+    it('should clear expired token from localStorage', () => {
+      // Token expired 10 minutes ago (beyond 5-minute tolerance)
+      const expiredJwt = createJwtWithExp(Math.floor(Date.now() / 1000) - 10 * 60)
+      localStorage.setItem('loggedInUser', JSON.stringify({ token: expiredJwt }))
+
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideTranslateService(),
+          AuthService,
+          { provide: Router, useValue: routerSpy },
+          provideHttpClient(),
+          provideHttpClientTesting()
+        ]
+      })
+
+      const newService = TestBed.inject(AuthService)
+      const newHttpMock = TestBed.inject(HttpTestingController)
+
+      // Should not make a server call for expired tokens
+      newHttpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/devices/stats`)
+
+      expect(newService.isLoggedIn).toBeFalse()
+      expect(localStorage.getItem('loggedInUser')).toBeNull()
+      newHttpMock.verify()
+    })
+
+    it('should clear malformed token from localStorage', () => {
+      localStorage.setItem('loggedInUser', JSON.stringify({ token: 'bad.jwt' }))
+
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideTranslateService(),
+          AuthService,
+          { provide: Router, useValue: routerSpy },
+          provideHttpClient(),
+          provideHttpClientTesting()
+        ]
+      })
+
+      const newService = TestBed.inject(AuthService)
+      const newHttpMock = TestBed.inject(HttpTestingController)
+
+      // Should not make a server call for malformed tokens
+      newHttpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/devices/stats`)
+
+      expect(newService.isLoggedIn).toBeFalse()
+      expect(localStorage.getItem('loggedInUser')).toBeNull()
+      newHttpMock.verify()
+    })
+
+    it('should handle corrupted localStorage JSON gracefully', () => {
+      // Simulate corrupted localStorage (invalid JSON)
+      localStorage.setItem('loggedInUser', 'not-valid-json{]')
+
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideTranslateService(),
+          AuthService,
+          { provide: Router, useValue: routerSpy },
+          provideHttpClient(),
+          provideHttpClientTesting()
+        ]
+      })
+
+      const newService = TestBed.inject(AuthService)
+      const newHttpMock = TestBed.inject(HttpTestingController)
+
+      // Should not crash app startup
+      newHttpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/devices/stats`)
+
+      // Should clear corrupted data and not be logged in
+      expect(newService.isLoggedIn).toBeFalse()
+      expect(localStorage.getItem('loggedInUser')).toBeNull()
+      newHttpMock.verify()
     })
   })
 })

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -16,14 +16,23 @@ import { OAuthService } from 'angular-oauth2-oidc'
   providedIn: 'root'
 })
 export class AuthService {
+  // Clock skew tolerance for distributed systems
+  // Allows 5 minutes for clock differences between client, edge nodes, and backend
+  // This handles timezone/NTP drift without allowing truly expired tokens through
+  private static readonly clockSkewToleranceMs = 5 * 60 * 1000
   private readonly http = inject(HttpClient)
   private oauthService
   router = inject(Router)
   loggedInSubject$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false)
+  private authStateInitialized$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false)
 
   public canActivateProtectedRoutes$: Observable<boolean> = combineLatest([
-    this.loggedInSubject$
-  ]).pipe(map((values) => values.every((b) => b)))
+    this.loggedInSubject$,
+    this.authStateInitialized$
+  ]).pipe(
+    filter(([, initialized]) => initialized),
+    map(([isLoggedIn]) => isLoggedIn)
+  )
 
   isLoggedIn = false
   url = `${environment.mpsServer}/api/v1/authorize`
@@ -32,10 +41,15 @@ export class AuthService {
     if (environment.useOAuth) {
       this.oauthService = inject(OAuthService)
     }
-    if (localStorage.loggedInUser != null) {
-      this.isLoggedIn = true
-      this.loggedInSubject$.next(this.isLoggedIn)
+    // Only restore from localStorage for JWT-based auth, not OAuth
+    if (!environment.useOAuth) {
+      if (localStorage.getItem('loggedInUser') != null) {
+        this.restoreSessionFromStorage()
+      } else {
+        this.authStateInitialized$.next(true)
+      }
     }
+    // OAuth initialization happens below after access token validity is checked
     if (environment.mpsServer.includes('/mps')) {
       // handles kong route
       this.url = `${environment.mpsServer}/login/api/v1/authorize`
@@ -46,6 +60,7 @@ export class AuthService {
       })
 
       this.loggedInSubject$.next(this.oauthService.hasValidAccessToken())
+      this.authStateInitialized$.next(true)
 
       this.oauthService.events
         .pipe(filter((e) => ['session_terminated', 'session_error'].includes(e.type)))
@@ -108,10 +123,81 @@ export class AuthService {
   getLoggedUserToken(): string {
     const loggedInUser: string = localStorage.getItem('loggedInUser') ?? ''
     if (loggedInUser !== '') {
-      const token: string = JSON.parse(loggedInUser).token
-      return token
+      try {
+        const token: string = JSON.parse(loggedInUser).token
+        return token
+      } catch {
+        // Corrupted localStorage - clear it to allow app recovery
+        localStorage.removeItem('loggedInUser')
+        return ''
+      }
     }
     return ''
+  }
+
+  private restoreSessionFromStorage(): void {
+    const token = this.getLoggedUserToken()
+    if (!token) {
+      this.clearSessionAndMarkInitialized()
+      return
+    }
+
+    // Validate token client-side
+    if (!this.isTokenValidClientSide(token)) {
+      this.clearSessionAndMarkInitialized()
+      return
+    }
+
+    // Token is valid client-side, allow login but mark for validation
+    // The first API call will verify if the token is actually valid server-side
+    // If it gets a 401, the error interceptor will handle logout
+    this.isLoggedIn = true
+    this.loggedInSubject$.next(true)
+    this.authStateInitialized$.next(true)
+  }
+
+  private isTokenValidClientSide(token: string): boolean {
+    try {
+      const payloadPart = token.split('.')[1]
+      if (!payloadPart) {
+        return false
+      }
+
+      const payload = JSON.parse(this.decodeBase64Url(payloadPart)) as { exp?: number }
+      if (typeof payload.exp !== 'number') {
+        return false
+      }
+
+      // Check if token is expired, with tolerance for clock skew
+      // In distributed systems, client/edge/backend clocks may differ
+      // Allow tokens that expired within the last 5 minutes (clock skew tolerance)
+      // but reject anything older than that
+      const expirationMs = payload.exp * 1000
+      const now = Date.now()
+
+      // Token is valid if: expiration time + tolerance > current time
+      // This means tokens expired >5 minutes ago are rejected
+      return expirationMs + AuthService.clockSkewToleranceMs > now
+    } catch {
+      return false
+    }
+  }
+
+  private clearSession(): void {
+    localStorage.removeItem('loggedInUser')
+    this.isLoggedIn = false
+    this.loggedInSubject$.next(false)
+  }
+
+  private clearSessionAndMarkInitialized(): void {
+    this.clearSession()
+    this.authStateInitialized$.next(true)
+  }
+
+  private decodeBase64Url(value: string): string {
+    const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=')
+    return atob(padded)
   }
 
   login(username: string, password: string): Observable<any> {
@@ -121,6 +207,7 @@ export class AuthService {
           this.isLoggedIn = true
           localStorage.loggedInUser = JSON.stringify(data)
           this.loggedInSubject$.next(this.isLoggedIn)
+          this.authStateInitialized$.next(true)
         }
         return data
       }),
@@ -133,6 +220,7 @@ export class AuthService {
   logout(): void {
     this.isLoggedIn = false
     this.loggedInSubject$.next(this.isLoggedIn)
+    this.authStateInitialized$.next(true)
     localStorage.removeItem('loggedInUser')
     if (environment.useOAuth) {
       this.oauthService?.logOut()

--- a/src/app/authorize.interceptor.spec.ts
+++ b/src/app/authorize.interceptor.spec.ts
@@ -49,10 +49,19 @@ describe('AuthorizeInterceptor', () => {
   })
 
   it('should not add Authorization header for /authorize endpoint', () => {
-    httpClient.get('/authorize').subscribe()
+    httpClient.get('/api/v1/authorize').subscribe()
 
-    const req = httpTestingController.expectOne('/authorize')
+    const req = httpTestingController.expectOne('/api/v1/authorize')
     expect(req.request.headers.has('Authorization')).toBeFalse()
+  })
+
+  it('should add Authorization header for /authorize/validate endpoint', () => {
+    authServiceSpy.getLoggedUserToken.and.returnValue('test-token')
+
+    httpClient.get('/api/v1/authorize/validate').subscribe()
+
+    const req = httpTestingController.expectOne('/api/v1/authorize/validate')
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token')
   })
 
   it('should add if-match header if body contains version', () => {

--- a/src/app/authorize.interceptor.ts
+++ b/src/app/authorize.interceptor.ts
@@ -9,9 +9,11 @@ import { AuthService } from './auth.service'
 
 export const authorizationInterceptor: HttpInterceptorFn = (request, next) => {
   const authService = inject(AuthService)
+  const url = request.url.toString()
+  const isLoginEndpoint = /\/(login\/)?api\/v1\/authorize$/.test(url)
 
-  if (request.url.toString().includes('/authorize') && !request.url.toString().includes('/authorize/redirection')) {
-    // Skip adding authorization headers for specific routes
+  if (isLoginEndpoint) {
+    // Login endpoint should not include bearer token.
     return next(request)
   }
 


### PR DESCRIPTION
Fixes first-load 401 errors on /api/v1/devices/stats when stale JWT exists in localStorage.

Addresses device-management-toolkit/console#993

Root cause: 
Original code didn't validate JWT expiration before trusting tokens from localStorage. In distributed systems, client/edge/backend clocks may differ due to timezone and NTP drift.

Solution: 
Add JWT validation with 5-minute clock skew tolerance:
- Tokens expired >5 minutes: rejected immediately, redirect to login
- Tokens expired <5 minutes: accepted (handles clock differences)
- Valid tokens: accepted, dashboard loads normally

Changes:
- Add restoreSessionFromStorage() to validate JWT expiration
- Add 5-minute clock skew tolerance (industry standard)
- Add authStateInitialized$ to prevent race conditions
- Fix authorize interceptor regex to only exclude login endpoint
- Add comprehensive test coverage

Clock skew tolerance (5 minutes) handles:
* Timezone differences between client and server
* NTP clock drift in edge nodes
* Distributed system clock variations
* Rejects tokens expired >5 minutes ago

Testing:

Prerequisites:
Browser and host/server time must match!

Check times match:

In terminal
```bash
date
```

In sample-web-ui browser F12 console
```bash
console.log(new Date().toString());
```

If times differ by >5 minutes, fix before testing:
- Close all browser windows and restart
- Or sync system time: `sudo timedatectl set-ntp true`

Unit tests

```bash
npm test -- --include='**/auth.service.spec.ts' --browsers=ChromeHeadless --watch=false
npm test -- --include='**/authorize.interceptor.spec.ts' --browsers=ChromeHeadless --watch=false
```

# Testing with Console

Backend API Tests (curl)

Test 1: Fresh Valid Token

```bash
BASE="https://localhost:8181"
USER="username"
PASS="password"
```

Login and get token

```bash
TOKEN=$(curl -sk -X POST "$BASE/api/v1/authorize" \
  -H "Content-Type: application/json" \
  -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}" | \
  grep -o '"token":"[^"]*"' | cut -d'"' -f4)
```

```bash
echo "Token: $TOKEN"
```

Test with backend

```bash
curl -sk -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/devices/stats"
```
Expected: HTTP 200 {"totalCount":0,"connectedCount":0,"disconnectedCount":0}


Test 2: Expired Token (10 minutes ago)

Create expired token

```bash
EXPIRED=$(node -e "
  const b64url = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
  const exp = Math.floor(Date.now() / 1000) - (10 * 60);
  console.log(b64url({alg:'HS256'}) + '.' + b64url({exp}) + '.fake');
")
```

Test with backend

```bash
curl -sk -H "Authorization: Bearer $EXPIRED" "$BASE/api/v1/devices/stats"
```
Expected: HTTP 401 {"error":"invalid access token"}

Test 3: Invalid/No Token

Malformed token

```bash
curl -sk -H "Authorization: Bearer bad.token" "$BASE/api/v1/devices/stats"
```
Expected: HTTP 401 {"error":"invalid access token"}

No token

```bash
curl -sk "$BASE/api/v1/devices/stats"
```
Expected: HTTP 401 {"error":"request does not contain an access token"}

# Testing with Cloud

Kong does the JWT validation and not MPS 
Endpoints through Kong: /mps/login/api/v1/authorize and /mps/api/v1/devices/stats
cloud base url should be https://ipaddress:443/ and not http://localhost:3000

```bash
git clone -b v2 --recursive https://github.com/device-management-toolkit/deployment.git deployment-v2
cd deployment-v2
cp .env.template .env
```

Edit .env and kong.yaml as mentioned in documentation https://device-management-toolkit.github.io/docs/2.36/GetStarted/Cloud/setup/

```bash
cd /home/hspe/sinchana/deployment-v2/sample-web-ui
git fetch origin
git checkout issue993-console

docker compose up -d --build (gives proxy error)
or
docker compose build \
  --build-arg http_proxy=<value-here> \
  --build-arg https_proxy=<value-here> \
  --build-arg no_proxy="no proxy values"
docker compose up -d
docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Names}}"
```

Testing via curl cmds

Test 1: Login and get valid token

```bash
BASE="https://localhost:443"
USER="hspeoob"
PASS="Openamt-2026"
```

```bash
TOKEN=$(curl -sk -X POST "$BASE/mps/login/api/v1/authorize" \
  -H "Content-Type: application/json" \
  -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}" | \
  grep -o '"token":"[^"]*"' | cut -d'"' -f4)
```

```bash
echo "Token: $TOKEN"
```

Test 2: Valid token - should work

```bash
curl -sk -H "Authorization: Bearer $TOKEN" "$BASE/mps/api/v1/devices/stats"
```
Expected: {"totalCount":0,"connectedCount":0,"disconnectedCount":0}

Test 3: Expired token (10 minutes ago) - should fail

```bash
EXPIRED=$(node -e "
  const b64url = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
  const exp = Math.floor(Date.now() / 1000) - (10 * 60);
  console.log(b64url({alg:'HS256'}) + '.' + b64url({exp}) + '.fake');
")
```

```bash
curl -sk -H "Authorization: Bearer $EXPIRED" "$BASE/mps/api/v1/devices/stats"
```
Expected: HTTP 401 {"message":"No mandatory 'iss' in claims"}

Test 4: Malformed token - should fail

```bash
curl -sk -H "Authorization: Bearer bad.token" "$BASE/mps/api/v1/devices/stats"
```
Expected: HTTP 401 {"message":"Bad token; invalid JSON"}

Test 5: No token - should fail

```bash
curl -sk "$BASE/mps/api/v1/devices/stats"
```
Expected: HTTP 401 {"message": "Unauthorized"}



Manual Browser Tests

Test 1: Valid Token (Should Stay Logged In)
* Login at `http://localhost:4200`
* Wait for dashboard
* Press F5 to refresh

Expected: Stays logged in, dashboard loads

Test 2: Expired Token - Beyond Tolerance (Should Redirect to Login)
* Login and wait for dashboard
* Press F12 → Go to Console tab
* Copy and paste this (one command at a time):

```javascript
const b64 = (o) => btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
```

```javascript
const expired = b64({ alg: 'HS256', typ: 'JWT' }) + '.' + b64({ exp: Math.floor(Date.now() / 1000) - 600 }) + '.x';
```

```javascript
localStorage.setItem('loggedInUser', JSON.stringify({ token: expired })); location.href = '/';
```

What this does: Creates token expired 10 minutes ago (beyond 5-min tolerance)
Expected: 
- Redirects to `/login` immediately
- No 401 error in Network tab
- No error dialog

Test 3: Expired Token - Within Tolerance (Should Stay Logged In)
* Login and wait for dashboard
* Press F12 → Go to Console tab
* Copy and paste this (one command at a time):

```javascript
const b64 = (o) => btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
```

```javascript
const expired = b64({ alg: 'HS256', typ: 'JWT' }) + '.' + b64({ exp: Math.floor(Date.now() / 1000) - 180 }) + '.x';
```

```javascript
localStorage.setItem('loggedInUser', JSON.stringify({ token: expired })); location.href = '/';
```

What this does: Creates token expired 3 minutes ago (within 5-min tolerance)

Expected behavior:
1. Client validation: Token expired 3 min → Within 5-min tolerance → VALID
2. Client allows dashboard to load (proves client validation worked!)
3. Dashboard makes API call → Server rejects fake signature (`.x`) → 401
4. Error interceptor catches 401 → Logs out → Redirects to login
Note: The 401 error is from the fake signature, not expiration. The key proof that clock tolerance works is that dashboard loaded (unlike Test 2 where client rejected immediately before loading).

Helper:

Check Current Token Status

To see your token expiration, press F12 → Console → Run:

```javascript
const user = JSON.parse(localStorage.getItem('loggedInUser'));
const payload = JSON.parse(atob(user.token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
const exp = new Date(payload.exp * 1000);
console.log('Expires:', exp.toString());
console.log('Expired:', exp < new Date());
```

Debugging

Check Token Details
// In browser console
```javascript
const user = JSON.parse(localStorage.getItem('loggedInUser'));
if (user && user.token) {
  const payload = JSON.parse(atob(user.token.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));
  const exp = new Date(payload.exp * 1000);
  const now = new Date();
  const tolerance = 5 * 60 * 1000;
  
  console.log('Expires:', exp);
  console.log('Now:', now);
  console.log('Expired:', exp < now);
  console.log('Valid (with tolerance):', (exp.getTime() + tolerance) > now.getTime());
}
```

Monitor Network
1. DevTools → Network tab
2. Filter: "stats"
3. Look for `/api/v1/devices/stats`
4. Check status: 200 = valid, 401 = invalid

Understanding 5-Minute Tolerance

Why needed?
- Client browser can be any timezone
- Edge nodes deployed globally
- NTP drift between servers

How it works:
```
Token expires: 10:00
Current: 10:03 (3 min past) → VALID (within 5-min tolerance)
Current: 10:07 (7 min past) → INVALID (beyond tolerance)
```

Industry standard: OAuth 2.0, JWT RFC, Auth0, AWS, Google all use 5-10 minutes

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
