### PR TITLE
test: split Cloud and Console activation and deactivation coverage

### DIFF
--- a/cypress/e2e/integration/rpc/cloud.activation.spec.ts
+++ b/cypress/e2e/integration/rpc/cloud.activation.spec.ts
@@ -18,11 +18,10 @@ import {
   execWithRetry,
   buildInfoCommand,
   buildActivateCommand,
-  buildDeactivateCommand,
   getAmtInfo,
   getAmtVersion,
   notActivatedControlModes
-} from './activation.spec'
+} from './rpc.helpers'
 
 if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
   {
@@ -40,7 +39,6 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
     // Default: use Docker (Linux/Mac); Windows overrides handled internally by the builders.
     const infoCommand = buildInfoCommand({ isWin, rpcDockerImage })
     let activateCommand = ''
-    let deactivateCommand = ''
     let amtVersion = ''
 
     before(() => {
@@ -53,18 +51,34 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
           fqdn,
           profileName
         })
-        deactivateCommand = buildDeactivateCommand({
-          isWin,
-          rpcDockerImage,
-          password,
-          amtVersion,
-          fqdn
-        })
       })
     })
 
+    context('Negative Activation Test', () => {
+      if (isAdminControlModeProfile) {
+        it('Should NOT activate ACM when domain suffix is not registered in RPS', () => {
+          // Confirm the negative activation starts from an unprovisioned device.
+          cy.setup()
+          getAmtInfo(infoCommand).then((info) => {
+            expect(info.controlMode).to.be.oneOf(notActivatedControlModes)
+          })
+
+          // Reject the domain suffix without changing the AMT activation state.
+          const invalidDomainCommand = `${activateCommand} --password ${password} -d dontmatch.com`
+          execWithRetry(invalidDomainCommand, execConfig).then((result) => {
+            const { combined } = buildOutput(result)
+            cy.log(combined)
+            expect(combined).to.contain(
+              'Specified AMT domain suffix: dontmatch.com does not match list of available AMT domain suffixes.'
+            )
+          })
+          getAmtInfo(infoCommand).its('controlMode').should('be.oneOf', notActivatedControlModes)
+        })
+      }
+    })
+
     describe('Device Activation - Cloud', () => {
-      context('TC_ACTIVATION_DEVICE_ACTIVATE_AND_DEACTIVATE', () => {
+      context('TC_ACTIVATION_DEVICE_ACTIVATE', () => {
         beforeEach(() => {
           cy.setup()
           getAmtInfo(infoCommand).then((info) => {
@@ -88,7 +102,6 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
               return
             }
 
-            expect(combined).not.to.match(/failed/i)
             if (isAdminControlModeProfile) {
               expect(combined).to.match(/admin control mode/i)
             } else {
@@ -96,17 +109,18 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
             }
 
             if (parts[2] === 'CIRA') {
-              expect(combined).to.match(/CIRA: Configured/i)
+              expect(combined).to.match(/CIRA(?::|\s+)(?:Connection:?\s*)?Configured/i)
             } else if (parseInt(amtVersion) >= 19) {
-              expect(combined).to.match(/TLS: Already Configured/i)
+              expect(combined).to.match(/TLS:\s*(?:Already )?Configured/i)
             } else {
               expect(combined).to.match(/TLS: Configured/i)
             }
 
             if (profileName.endsWith('WiFi')) {
-              expect(combined).to.contain('Network: Wired Network Configured. Wireless Configured')
+              expect(combined).to.match(/(?:Wired )?Network:\s*Wired Network Configured/i)
+              expect(combined).to.match(/Wireless(?: Network)?:?\s*(?:Wireless )?Configured/i)
             } else {
-              expect(combined).to.contain('Network: Wired Network Configured')
+              expect(combined).to.match(/(?:Wired )?Network:\s*Wired Network Configured/i)
             }
 
             if (primaryOutput.length > 0) {
@@ -157,45 +171,7 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
             }
           })
         })
-
-        it('should NOT deactivate device - invalid password', () => {
-          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
-            const invalidCommand =
-              deactivateCommand.slice(0, deactivateCommand.indexOf('--password')) + '--password invalidpassword'
-            execWithRetry(invalidCommand, execConfig).then((result) => {
-              const { combined } = buildOutput(result)
-              cy.log(combined)
-              expect(combined).to.contain('Unable to authenticate with AMT')
-            })
-          }
-        })
-
-        it('should deactivate device', () => {
-          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
-            execWithRetry(deactivateCommand, execConfig).then((result) => {
-              const { combined } = buildOutput(result)
-              cy.log(combined)
-              expect(combined).to.contain('Status: Deactivated')
-              cy.wait(15000)
-            })
-          }
-        })
       })
-    })
-
-    context('Negative Activation Test', () => {
-      if (isAdminControlModeProfile) {
-        it('Should NOT activate ACM when domain suffix is not registered in RPS', () => {
-          activateCommand += ' -d dontmatch.com'
-          execWithRetry(activateCommand, execConfig).then((result) => {
-            const { combined } = buildOutput(result)
-            cy.log(combined)
-            expect(combined).to.contain(
-              'Specified AMT domain suffix: dontmatch.com does not match list of available AMT domain suffixes.'
-            )
-          })
-        })
-      }
     })
   }
 }

--- a/cypress/e2e/integration/rpc/cloud.deactivation.spec.ts
+++ b/cypress/e2e/integration/rpc/cloud.deactivation.spec.ts
@@ -1,0 +1,72 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import {
+  AMTInfo,
+  buildDeactivateCommand,
+  buildInfoCommand,
+  buildOutput,
+  execConfig,
+  execWithRetry,
+  getAmtInfo,
+  getAmtVersion,
+  notActivatedControlModes
+} from './rpc.helpers'
+
+if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
+  let amtInfo: AMTInfo
+  const password: string = Cypress.env('AMT_PASSWORD')
+  const fqdn: string = Cypress.env('ACTIVATION_URL')
+  const rpcDockerImage: string = Cypress.env('RPC_DOCKER_IMAGE')
+  const isWin = Cypress.platform === 'win32'
+  const infoCommand = buildInfoCommand({ isWin, rpcDockerImage })
+  let deactivateCommand = ''
+
+  before(() => {
+    getAmtInfo(infoCommand).then((info) => {
+      deactivateCommand = buildDeactivateCommand({
+        isWin,
+        rpcDockerImage,
+        password,
+        amtVersion: getAmtVersion(info),
+        fqdn
+      })
+    })
+  })
+
+  describe('Device Deactivation - Cloud', () => {
+    context('TC_DEACTIVATION_DEVICE_DEACTIVATE', () => {
+      beforeEach(() => {
+        cy.setup()
+        getAmtInfo(infoCommand).then((info) => {
+          amtInfo = info
+          expect(info.controlMode, 'Device must be activated before deactivation').not.to.be.oneOf(
+            notActivatedControlModes
+          )
+        })
+      })
+
+      it('should NOT deactivate device with an invalid password', () => {
+        const invalidCommand = deactivateCommand.replace(/--password\s+\S+/, '--password invalidpassword')
+        execWithRetry(invalidCommand, execConfig).then((result) => {
+          const { combined } = buildOutput(result)
+          cy.log(combined)
+          expect(combined).to.contain('Unable to authenticate with AMT')
+        })
+      })
+
+      it('should deactivate device and verify the final control mode', () => {
+        expect(amtInfo.controlMode).not.to.be.oneOf(notActivatedControlModes)
+        execWithRetry(deactivateCommand, execConfig).then((result) => {
+          const { combined } = buildOutput(result)
+          cy.log(combined)
+          expect(combined).to.contain('Status: Deactivated')
+          cy.wait(15000)
+          getAmtInfo(infoCommand).its('controlMode').should('be.oneOf', notActivatedControlModes)
+        })
+      })
+    })
+  })
+}

--- a/cypress/e2e/integration/rpc/console.activation.spec.ts
+++ b/cypress/e2e/integration/rpc/console.activation.spec.ts
@@ -18,11 +18,10 @@ import {
   execWithRetry,
   buildInfoCommand,
   buildActivateCommand,
-  buildDeactivateCommand,
   getAmtInfo,
   getAmtVersion,
   notActivatedControlModes
-} from './activation.spec'
+} from './rpc.helpers'
 
 if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
   {
@@ -30,7 +29,6 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
 
     // Environment variables
     const profileName: string = Cypress.env('PROFILE_NAME') as string
-    const password: string = Cypress.env('AMT_PASSWORD')
     const rpcDockerImage: string = Cypress.env('RPC_DOCKER_IMAGE')
     const parts: string[] = profileName ? profileName.split('-') : []
     const isAdminControlModeProfile = parts.length > 0 && parts[0] === 'acmactivate'
@@ -41,7 +39,6 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
     // Default: use Docker (Linux/Mac); Windows overrides handled internally by the builders.
     const infoCommand = buildInfoCommand({ isWin, rpcDockerImage })
     let activateCommand = ''
-    let deactivateCommand = ''
     let amtVersion = ''
 
     before(() => {
@@ -54,18 +51,11 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
           profileYamlFile,
           encryptionKey
         })
-        deactivateCommand = buildDeactivateCommand({
-          isWin,
-          rpcDockerImage,
-          password,
-          amtVersion,
-          isAdminControlModeProfile
-        })
       })
     })
 
     describe('Device Activation - Console', () => {
-      context('TC_ACTIVATION_DEVICE_ACTIVATE_AND_DEACTIVATE', () => {
+      context('TC_ACTIVATION_DEVICE_ACTIVATE', () => {
         beforeEach(() => {
           cy.setup()
           getAmtInfo(infoCommand).then((info) => {
@@ -152,32 +142,6 @@ if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
               cy.get('[data-cy="auditLogEntry"]').its('length').should('be.gt', 0)
             }
           })
-        })
-
-        it('should NOT deactivate device - invalid password', function () {
-          if (!isAdminControlModeProfile) {
-            this.skip()
-          }
-
-          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
-            const invalidCommand =
-              deactivateCommand.slice(0, deactivateCommand.indexOf('--password')) + '--password invalidpassword'
-            execWithRetry(invalidCommand, execConfig).then((result) => {
-              const { combined } = buildOutput(result)
-              cy.log(combined)
-              expect(combined).to.contain('Error 109: UnableToDeactivate')
-            })
-          }
-        })
-
-        it('should deactivate device', () => {
-          if (!notActivatedControlModes.includes(amtInfo.controlMode)) {
-            execWithRetry(deactivateCommand, execConfig).then((result) => {
-              const { combined } = buildOutput(result)
-              cy.log(combined)
-              expect(combined).to.contain('Status: Device deactivated')
-            })
-          }
         })
       })
     })

--- a/cypress/e2e/integration/rpc/console.deactivation.spec.ts
+++ b/cypress/e2e/integration/rpc/console.deactivation.spec.ts
@@ -1,0 +1,76 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import {
+  AMTInfo,
+  buildDeactivateCommand,
+  buildInfoCommand,
+  buildOutput,
+  execConfig,
+  execWithRetry,
+  getAmtInfo,
+  getAmtVersion,
+  notActivatedControlModes
+} from './rpc.helpers'
+
+if (Cypress.env('ISOLATE').charAt(0).toLowerCase() !== 'y') {
+  let amtInfo: AMTInfo
+  const profileName: string = Cypress.env('PROFILE_NAME') as string
+  const password: string = Cypress.env('AMT_PASSWORD')
+  const rpcDockerImage: string = Cypress.env('RPC_DOCKER_IMAGE')
+  const isAdminControlModeProfile = profileName.startsWith('acmactivate')
+  const isWin = Cypress.platform === 'win32'
+  const infoCommand = buildInfoCommand({ isWin, rpcDockerImage })
+  let deactivateCommand = ''
+
+  before(() => {
+    getAmtInfo(infoCommand).then((info) => {
+      deactivateCommand = buildDeactivateCommand({
+        isWin,
+        rpcDockerImage,
+        password,
+        amtVersion: getAmtVersion(info),
+        isAdminControlModeProfile
+      })
+    })
+  })
+
+  describe('Device Deactivation - Console', () => {
+    context('TC_DEACTIVATION_DEVICE_DEACTIVATE', () => {
+      beforeEach(() => {
+        cy.setup()
+        getAmtInfo(infoCommand).then((info) => {
+          amtInfo = info
+          expect(info.controlMode, 'Device must be activated before deactivation').not.to.be.oneOf(
+            notActivatedControlModes
+          )
+        })
+      })
+
+      it('should NOT deactivate an ACM device with an invalid password', function () {
+        if (!isAdminControlModeProfile) {
+          this.skip()
+        }
+
+        const invalidCommand = deactivateCommand.replace(/--password\s+\S+/, '--password invalidpassword')
+        execWithRetry(invalidCommand, execConfig).then((result) => {
+          const { combined } = buildOutput(result)
+          cy.log(combined)
+          expect(combined).to.contain('Error 109: UnableToDeactivate')
+        })
+      })
+
+      it('should deactivate device and verify the final control mode', () => {
+        expect(amtInfo.controlMode).not.to.be.oneOf(notActivatedControlModes)
+        execWithRetry(deactivateCommand, execConfig).then((result) => {
+          const { combined } = buildOutput(result)
+          cy.log(combined)
+          expect(combined).to.contain('Status: Device deactivated')
+          getAmtInfo(infoCommand).its('controlMode').should('be.oneOf', notActivatedControlModes)
+        })
+      })
+    })
+  })
+}

--- a/cypress/e2e/integration/rpc/deactivation.spec.ts
+++ b/cypress/e2e/integration/rpc/deactivation.spec.ts
@@ -8,7 +8,7 @@ import { isCloud } from './rpc.helpers'
 declare const require: (id: string) => unknown
 
 if (isCloud) {
-  require('./cloud.activation.spec')
+  require('./cloud.deactivation.spec')
 } else {
-  require('./console.activation.spec')
+  require('./console.deactivation.spec')
 }

--- a/cypress/e2e/integration/rpc/rpc.helpers.ts
+++ b/cypress/e2e/integration/rpc/rpc.helpers.ts
@@ -1,0 +1,195 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// ---- Shared helpers --------------------------------------------------------
+
+export interface AMTInfo {
+  amt: string
+  buildNumber: string
+  controlMode: string
+  dnsSuffix: string
+  dnsSuffixOS: string
+  hostnameOS: string
+  ras: {
+    networkStatus: string
+    remoteStatus: string
+    remoteTrigger: string
+    mpsHostname: string
+  }
+  sku: string
+  uuid: string
+  wiredAdapter: {
+    isEnable: boolean
+    linkStatus: string
+    dhcpEnabled: boolean
+    dhcpMode: string
+    ipAddress: string
+    macAddress: string
+  }
+  wirelessAdapter: {
+    isEnable: boolean
+    linkStatus: string
+    dhcpEnabled: boolean
+    dhcpMode: string
+    ipAddress: string
+    macAddress: string
+  }
+}
+
+export const execConfig: Cypress.ExecOptions = {
+  log: true,
+  failOnNonZeroExit: false,
+  timeout: 240000
+} as any
+
+export const buildOutput = (result: { stdout?: string; stderr?: string }) => {
+  const stdout = result.stdout ? result.stdout.trim() : ''
+  const stderr = result.stderr ? result.stderr.trim() : ''
+  const combined = [stdout, stderr].filter((value) => value.length > 0).join('\n')
+  return { stdout, stderr, combined }
+}
+
+export const execWithRetry = (
+  command: string,
+  config: Cypress.ExecOptions,
+  maxRetries = 5,
+  retryInterval = 5000
+): Cypress.Chainable<Cypress.Exec> => {
+  const attemptExec = (attempt: number): Cypress.Chainable<Cypress.Exec> => {
+    return cy.exec(command, config).then((result) => {
+      const { combined } = buildOutput(result)
+
+      if (combined.includes('interrupted system call') && attempt < maxRetries) {
+        cy.log(`Retry attempt ${attempt + 1}/${maxRetries} after interrupted system call error`)
+        cy.wait(retryInterval)
+        return attemptExec(attempt + 1)
+      }
+
+      return cy.wrap(result)
+    })
+  }
+
+  return attemptExec(1)
+}
+
+// Runs `rpc amtinfo` and parses the JSON result. Tolerates leading log noise
+// (e.g. logrus-formatted warnings) by locating the first '{' in the output.
+export const getAmtInfo = (
+  infoCommand: string,
+  config: Cypress.ExecOptions = execConfig
+): Cypress.Chainable<AMTInfo> => {
+  return cy.exec(infoCommand, config).then((result) => {
+    const { stdout, stderr, combined } = buildOutput(result)
+    return cy.log(combined).then(() => {
+      const source = stdout.length > 0 ? stdout : stderr
+      const jsonStart = source.indexOf('{')
+      if (jsonStart < 0) {
+        throw new Error(`rpc amtinfo did not return JSON. Output:\n${combined}`)
+      }
+      const jsonOutput = source.substring(jsonStart)
+      return JSON.parse(jsonOutput) as AMTInfo
+    })
+  })
+}
+
+// Extracts the major AMT version (e.g. "16.1.5" -> "16") from an AMTInfo object.
+export const getAmtVersion = (amtInfo: AMTInfo): string => {
+  const versions: string[] = amtInfo.amt.split('.')
+  return versions.length > 1 ? versions[0] : '0'
+}
+
+// rpc-go has reported the not-yet-activated control mode under different
+// strings across versions/builds; treat either as "not activated".
+export const notActivatedControlModes: string[] = ['pre-provisioning state', 'not activated']
+
+// ---- Computed environment flags -------------------------------------------
+
+// Exported so sub-specs (and the builders below) can use it to pick the
+// cloud vs. console command variant.
+export const isCloud: boolean = Cypress.env('CLOUD') === 'true' || Cypress.env('CLOUD') === true
+
+// ---- Shared rpc-go command builders ---------------------------------------
+//
+// rpc-go v3 (Kong CLI) requires --long/-short flag syntax; bare single-dash
+// long flags (e.g. -json, -configv2) are no longer accepted. Commands are run
+// either via Docker (Linux/Mac) or directly via rpc.exe (Windows). Each builder
+// uses `isCloud` to decide between the cloud (RPS/wss) and console (local
+// profile) variant of the command.
+
+export interface RpcCommandOptions {
+  isWin: boolean
+  rpcDockerImage: string
+  volumeMount?: string
+}
+
+const buildRpcCommand = (opts: RpcCommandOptions, winExe: string, args: string): string => {
+  if (opts.isWin) {
+    return `${winExe} ${args}`
+  }
+  const volumeFlag = opts.volumeMount ? ` -v ${opts.volumeMount}` : ''
+  return `docker run --rm --network host --device=/dev/mei0${volumeFlag} ${opts.rpcDockerImage} ${args}`
+}
+
+export const buildInfoCommand = (opts: RpcCommandOptions): string => buildRpcCommand(opts, 'rpc.exe', 'amtinfo --json')
+
+export interface ActivateCommandOptions {
+  isWin: boolean
+  rpcDockerImage: string
+  amtVersion: string
+  // console-only
+  profileYamlFile?: string
+  encryptionKey?: string
+  // cloud-only
+  fqdn?: string
+  profileName?: string
+}
+
+export const buildActivateCommand = (opts: ActivateCommandOptions): string => {
+  const commonFlag = '-v --json'
+  if (isCloud) {
+    const flagPart = parseInt(opts.amtVersion) <= 18 ? ' --tls-tunnel' : ''
+    const args = `activate -u wss://${opts.fqdn}/activate --profile ${opts.profileName} -n${flagPart} ${commonFlag}`
+    return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
+  }
+
+  const profileDir = opts.profileYamlFile
+    ? opts.profileYamlFile.substring(0, opts.profileYamlFile.lastIndexOf('/'))
+    : ''
+  const profileFileName = opts.profileYamlFile
+    ? opts.profileYamlFile.substring(opts.profileYamlFile.lastIndexOf('/') + 1)
+    : ''
+  const profilePath = opts.isWin ? opts.profileYamlFile : `/config/${profileFileName}`
+  const flagPart = parseInt(opts.amtVersion) <= 18 ? '' : ' --skip-amt-cert-check'
+  const args = `activate --profile ${profilePath} --key ${opts.encryptionKey}${flagPart} ${commonFlag}`
+  return buildRpcCommand(
+    { isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage, volumeMount: `${profileDir}:/config` },
+    'rpc.exe',
+    args
+  )
+}
+
+export interface DeactivateCommandOptions {
+  isWin: boolean
+  rpcDockerImage: string
+  password: string
+  amtVersion: string
+  // console-only
+  isAdminControlModeProfile?: boolean
+  // cloud-only
+  fqdn?: string
+}
+
+export const buildDeactivateCommand = (opts: DeactivateCommandOptions): string => {
+  const commonFlag = '-v -f --json'
+  if (isCloud) {
+    const args = `deactivate -u wss://${opts.fqdn}/activate -n --password ${opts.password} ${commonFlag}`
+    return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
+  }
+
+  const flagPart = parseInt(opts.amtVersion) <= 18 ? '' : ' --skip-amt-cert-check'
+  const passPart = opts.isAdminControlModeProfile ? ` --password ${opts.password}` : ''
+  const args = `deactivate --local${flagPart}${passPart} ${commonFlag}`
+  return buildRpcCommand({ isWin: opts.isWin, rpcDockerImage: opts.rpcDockerImage }, 'rpc.exe', args)
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?
- Refactors the RPC activation test into separate activation and deactivation test coverage for Cloud and Console deployments.
- Splits shared RPC command helpers into `rpc.helpers.ts`.
- Adds dedicated activation and deactivation entry specs with Cloud and Console implementations.
- Updates RPC-Go v3 command handling:
  - uses `--tls-tunnel` only for Cloud activation on AMT <= 18;
  - removes the unsupported tunnel flag from Cloud deactivation.

## Anything the reviewer should know when reviewing this PR?
Console Run: https://github.com/device-management-toolkit/e2e-testing/actions/runs/30246108743
Cloud Run: https://github.com/device-management-toolkit/e2e-testing/actions/runs/30240073255

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
