### PR TITLE
chore: release v3.61.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@device-management-toolkit/sample-web-ui",
-  "version": "3.61.0",
+  "version": "3.61.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@device-management-toolkit/sample-web-ui",
-      "version": "3.61.0",
+      "version": "3.61.1",
       "dependencies": {
         "@angular/animations": "~21.2.18",
         "@angular/cdk": "~21.2.3",
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "~21.2.18",
         "@angular/platform-browser-dynamic": "~21.2.18",
         "@angular/router": "~21.2.18",
-        "@device-management-toolkit/ui-toolkit-angular": "^11.1.6",
+        "@device-management-toolkit/ui-toolkit-angular": "^11.1.7",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "@xterm/xterm": "^6.0.0",
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/@device-management-toolkit/ui-toolkit": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/@device-management-toolkit/ui-toolkit/-/ui-toolkit-3.3.17.tgz",
-      "integrity": "sha512-n29PmFnbep5pfGFnftrDeXg5dG7JUbnTdsdTQssjF8If2Xcrh4A3jQJYmm8lIurWN/x5nU+k9TCAzsVaAOwREA==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/@device-management-toolkit/ui-toolkit/-/ui-toolkit-3.3.19.tgz",
+      "integrity": "sha512-KTwfhwjZiYVxaTICyU4D+++Vdkt5HGUDCM8WEl3WwZheJ/ewoRguKxkfbHf7xONfYsAG2Od2cSHnx1usojofkA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -2970,15 +2970,15 @@
       }
     },
     "node_modules/@device-management-toolkit/ui-toolkit-angular": {
-      "version": "11.1.6",
-      "resolved": "https://registry.npmjs.org/@device-management-toolkit/ui-toolkit-angular/-/ui-toolkit-angular-11.1.6.tgz",
-      "integrity": "sha512-Rqt5lJYw5/Z+vUK/Jg9XY17wE3fTykp4O4NhigCzzfTnHYlBAlDYqJBqfOWZ366iJHuea+SGuKkmhD9eWEvltQ==",
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/@device-management-toolkit/ui-toolkit-angular/-/ui-toolkit-angular-11.1.7.tgz",
+      "integrity": "sha512-zWAD+9Vnqlrz+VM+UY16pCUudiX/IukHkaua2e9pBXbaM06TFIlkUpmApULSCo1RggfnQQHqh89Hx3ERqQj/aQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@device-management-toolkit/ui-toolkit": "^3.3.17",
+        "@device-management-toolkit/ui-toolkit": "^3.3.19",
         "@xterm/xterm": "^6.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@device-management-toolkit/sample-web-ui",
-  "version": "3.61.0",
+  "version": "3.61.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -34,7 +34,7 @@
     "@angular/platform-browser": "~21.2.18",
     "@angular/platform-browser-dynamic": "~21.2.18",
     "@angular/router": "~21.2.18",
-    "@device-management-toolkit/ui-toolkit-angular": "^11.1.6",
+    "@device-management-toolkit/ui-toolkit-angular": "^11.1.7",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "@xterm/xterm": "^6.0.0",


### PR DESCRIPTION
## PR Checklist

- [x] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you''ve added a dependency, you''ve ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

Release v3.61.1.

- Bumps `@device-management-toolkit/ui-toolkit-angular` from `^11.1.6` to `^11.1.7`, which brings the `@device-management-toolkit/ui-toolkit` peer dependency from `3.3.17` to `3.3.19`. Both remain Apache-2.0.
- Sets the release version to `3.61.1` in `package.json` and `package-lock.json`.

## Anything the reviewer should know when reviewing this PR?

- No source changes — only `package.json` and `package-lock.json`.
- The lock was edited to touch only the affected entries, avoiding unrelated re-resolution churn (`libc` fields, `peer` flags) that a full `npm install` introduces with newer npm.
- Verified locally: `npm ci` (clean install off the lock), `npm run lint` (pass), `npm run test-ci` (751 passing, 0 failures), `npm run build` (pass).

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )

device-management-toolkit/ui-toolkit-angular#2530